### PR TITLE
fix: detect direct execution when launched through a symlinked bin

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,10 +3,11 @@
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { buildConfigFromEnv, createServer } from "./index.js";
+import { isMainModule } from "./is-main.js";
 import { SimpleIMAPService } from "./services/simple-imap-service.js";
 import type { EmailAddress, EmailDetail, EmailSummary, ProtonMailConfig, SearchEmailsInput } from "./types/index.js";
 import { ensureMailboxWriteAllowed, ensureSendAllowed, sanitizeRuntimeConfig } from "./utils/runtime-policy.js";
@@ -1896,8 +1897,7 @@ export async function main(): Promise<void> {
   }
 }
 
-const isDirectExecution =
-  Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+const isDirectExecution = isMainModule(import.meta.url);
 
 if (isDirectExecution) {
   main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve as pathResolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -16,6 +15,7 @@ import {
   McpError,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { isMainModule } from "./is-main.js";
 import { AnalyticsService } from "./services/analytics-service.js";
 import { AuditService } from "./services/audit-service.js";
 import { BackgroundSyncService } from "./services/background-sync-service.js";
@@ -5012,8 +5012,7 @@ process.on("unhandledRejection", (reason) => {
   process.exit(1);
 });
 
-const isDirectExecution =
-  Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+const isDirectExecution = isMainModule(import.meta.url);
 
 if (isDirectExecution) {
   main().catch((error) => {

--- a/src/is-main.ts
+++ b/src/is-main.ts
@@ -1,0 +1,33 @@
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Gives a filesystem path a stable identity, so two paths that reach the same
+ * file through different symlinks can be compared for equality. Paths that
+ * cannot be resolved are returned unchanged rather than throwing, so callers
+ * may still compare them literally.
+ */
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * Guards a module's "run as a script" block: pass the module's own
+ * `import.meta.url` and use the result to run startup logic only when that
+ * module is the one Node was launched with — the ESM counterpart of
+ * `require.main === module`, returning true in that case. Unlike a bare URL
+ * comparison it holds even when the entry point is reached through a symlink,
+ * such as a globally installed bin.
+ */
+export function isMainModule(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+
+  return canonicalPath(fileURLToPath(moduleUrl)) === canonicalPath(entry);
+}

--- a/test/is-main.test.mjs
+++ b/test/is-main.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { isMainModule } from "../dist/is-main.js";
+
+// Run `fn` with process.argv[1] temporarily set to `entry`, then restore it.
+function withEntry(entry, fn) {
+  const original = process.argv[1];
+  if (entry === undefined) {
+    delete process.argv[1];
+  } else {
+    process.argv[1] = entry;
+  }
+  try {
+    return fn();
+  } finally {
+    process.argv[1] = original;
+  }
+}
+
+test("returns false when there is no entry point", () => {
+  withEntry(undefined, () => {
+    assert.equal(isMainModule("file:///anything.js"), false);
+  });
+});
+
+test("matches the realpath-resolved entry (symlinked bin, default Node)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "protonmail-ismain-test-"));
+  try {
+    const real = join(dir, "real.js");
+    const link = join(dir, "link.js");
+    await writeFile(real, "");
+    await symlink(real, link);
+    // Launched via the symlink; default Node sets import.meta.url to the fully
+    // realpath-resolved entry (the link and any symlinked parent dir).
+    const resolvedUrl = pathToFileURL(await realpath(link)).href;
+    withEntry(link, () => {
+      assert.equal(isMainModule(resolvedUrl), true);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("matches the raw entry (symlinked bin, --preserve-symlinks-main)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "protonmail-ismain-test-"));
+  try {
+    const real = join(dir, "real.js");
+    const link = join(dir, "link.js");
+    await writeFile(real, "");
+    await symlink(real, link);
+    // import.meta.url keeps the symlink path under --preserve-symlinks-main.
+    withEntry(link, () => {
+      assert.equal(isMainModule(pathToFileURL(link).href), true);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("returns false for an unrelated module url", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "protonmail-ismain-test-"));
+  try {
+    const real = join(dir, "real.js");
+    await writeFile(real, "");
+    withEntry(real, () => {
+      assert.equal(isMainModule(pathToFileURL(join(dir, "other.js")).href), false);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("falls back to the raw entry when realpath cannot resolve it", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "protonmail-ismain-test-"));
+  try {
+    const missing = join(dir, "does-not-exist.js");
+    withEntry(missing, () => {
+      assert.equal(isMainModule(pathToFileURL(missing).href), true);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Installing the package globally (`npm install -g`, the method the README recommends) puts `proton-mail-bridge-mcp` and `proton-mail-bridge-client` on `PATH` as symlinks into `dist/`. Launched that way neither binary does anything: the process exits 0 with no output, and MCP clients report "Failed to connect". Running the same file directly with `node dist/index.js` works.

The direct-execution guard in `src/index.ts` (and `src/cli.ts`) compares `import.meta.url` against `pathToFileURL(process.argv[1])`. By default Node resolves symlinks when computing a module's URL, so `import.meta.url` is the real path (`…/dist/index.js`) while `process.argv[1]` stays the symlink path (`…/bin/proton-mail-bridge-mcp`). The two never match under a symlinked launch, `isDirectExecution` is false, and the startup block is skipped.

The guard now compares `import.meta.url` against both the entry as given and its `realpathSync`-resolved form, accepting a match on either. That covers both symlink modes: the default, where `import.meta.url` is resolved, and `--preserve-symlinks-main`, where it keeps the symlink path. `realpathSync` is the only added call that can throw — a missing or unreadable entry — so it is guarded, and on failure the check degrades to the original comparison, no worse than before. The plain `node dist/index.js` path is unaffected.

This went unnoticed because the `setup-claude-desktop` wizard writes the config with `command: process.execPath` and the resolved script path, so it never goes through the symlink. The setups that do hit it are the ones that invoke the bare bin name: hand-written Claude Desktop configs following the README's manual example, and Claude Code, which has no equivalent wizard — its users register the server by bin name (`claude mcp add … proton-mail-bridge-mcp`) and so hit this directly.

A unit test exercises the guard directly: the symlinked-entry case under both default and `--preserve-symlinks-main` resolution, an unrelated module URL, the no-entry case, and the `realpathSync`-failure fallback. The existing guarantee that importing `dist/index.js` does not start the server is unchanged.
