### PR TITLE
fix: exit stdio MCP server on client disconnect; stop IMAP IDLE busy-spin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4987,8 +4987,13 @@ export async function main(): Promise<void> {
   await server.connect(transport);
   logger.info("ProtonMail MCP server ready", "MCPServer");
 
-  const shutdown = async (signal: string) => {
-    logger.info(`Received ${signal}, shutting down`, "MCPServer");
+  let shuttingDown = false;
+  const shutdown = async (reason: string) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    logger.info(`Received ${reason}, shutting down`, "MCPServer");
     backgroundSyncService.stop();
     await Promise.allSettled([imapService.disconnect(), smtpService.close()]);
     process.exit(0);
@@ -4999,6 +5004,28 @@ export async function main(): Promise<void> {
   });
   process.on("SIGTERM", () => {
     void shutdown("SIGTERM");
+  });
+
+  // Lifecycle tie to the MCP client: this is a stdio server whose only consumer
+  // is the parent process (e.g. Claude Desktop) on the other end of the pipe.
+  // When that parent exits it closes our stdin; without this the background-sync
+  // timer and IMAP connection keep the event loop alive and the process is
+  // reparented to launchd/init and lingers forever (burning CPU). Exit as soon
+  // as the pipe closes so no orphan survives its consumer.
+  transport.onclose = () => {
+    void shutdown("transport-close");
+  };
+  process.stdin.on("end", () => {
+    void shutdown("stdin-end");
+  });
+  process.stdin.on("close", () => {
+    void shutdown("stdin-close");
+  });
+  // A broken pipe (parent killed abruptly) surfaces as an stdin error rather
+  // than a clean end; treat it the same way instead of crashing.
+  process.stdin.on("error", (error) => {
+    logger.warn("stdin error, shutting down", "MCPServer", error);
+    void shutdown("stdin-error");
   });
 }
 

--- a/src/services/background-sync-service.ts
+++ b/src/services/background-sync-service.ts
@@ -7,6 +7,10 @@ const AUTH_BACKOFF_MIN_MS = 5 * 60_000;
 const AUTH_BACKOFF_MAX_MS = 30 * 60_000;
 const TRANSIENT_BACKOFF_MIN_MS = 15_000;
 const TRANSIENT_BACKOFF_MAX_MS = 2 * 60_000;
+// Minimum wall-clock time a change-free IDLE watch iteration must occupy. Acts
+// as a hard floor so the idle loop can never busy-spin, independent of how the
+// underlying IMAP client behaves.
+const IDLE_ITERATION_FLOOR_MS = 1_000;
 
 export class BackgroundSyncService {
   private readonly status: BackgroundSyncStatus;
@@ -193,6 +197,7 @@ export class BackgroundSyncService {
       let failCount = 0;
       while (this.started && this.status.enabled && this.status.idleEnabled && this.status.folder) {
         this.status.idleWatching = true;
+        const iterationStartedAt = Date.now();
         try {
           const result = await this.imapService.waitForMailboxChanges({
             folder: this.status.folder,
@@ -205,6 +210,13 @@ export class BackgroundSyncService {
             this.status.lastIdleChangeAt = result.checkedAt;
             this.status.lastIdleEventCount = result.events.length;
             await this.runNow("idle");
+          } else {
+            // Backstop against a busy spin: a change-free watch cycle should have
+            // spent roughly idleMaxSeconds blocking in IDLE. If it returned far
+            // sooner (a no-op idle(), a fast-failing reconnect, or any future
+            // library regression), enforce a floor so this loop can never peg a
+            // CPU core the way an orphaned process once did.
+            await this.enforceIdleFloor(iterationStartedAt);
           }
         } catch (error) {
           this.status.lastIdleError = error instanceof Error ? error.message : String(error);
@@ -228,6 +240,14 @@ export class BackgroundSyncService {
       this.status.idleWatching = false;
       this.idleLoop = undefined;
     })();
+  }
+
+  private async enforceIdleFloor(iterationStartedAt: number): Promise<void> {
+    const elapsed = Date.now() - iterationStartedAt;
+    const remaining = IDLE_ITERATION_FLOOR_MS - elapsed;
+    if (remaining > 0) {
+      await this.waitForRetry(remaining);
+    }
   }
 
   private async waitForRetry(delayMs: number): Promise<void> {

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -66,6 +66,11 @@ const FETCH_INDEX_QUERY = {
 } as const;
 
 const MAX_ATTACHMENT_TEXT_BYTES = 512_000;
+// A healthy IMAP IDLE blocks until a mailbox change or the requested timeout.
+// If client.idle() returns faster than this with no events, IDLE never actually
+// engaged (e.g. imapflow's `idling` flag stuck true after Proton Bridge ended
+// the session server-side) and we must recover instead of busy-spinning.
+const MIN_HEALTHY_IDLE_MS = 500;
 const UID_VALIDITY_MISMATCH_ERROR = "UID validity mismatch - local index is stale, run sync_emails to refresh";
 
 export function isLikelyAuthenticationError(error: unknown): boolean {
@@ -395,6 +400,7 @@ export class SimpleIMAPService {
     const idleClient = client as unknown as {
       maxIdleTime?: number | false;
       preCheck?: false | (() => Promise<void>);
+      idling?: boolean;
     };
     const previousMaxIdle = idleClient.maxIdleTime;
     const events: Array<Record<string, unknown>> = [];
@@ -443,9 +449,43 @@ export class SimpleIMAPService {
 
     try {
       idleClient.maxIdleTime = timeoutMs;
+
+      // imapflow's client.idle() early-returns as a no-op when `idling` is
+      // already true (see imap-flow.js: `async idle() { if (!this.idling) ... }`).
+      // Proton Bridge can terminate an IDLE session server-side without our DONE,
+      // which leaves imapflow's `idling` stuck true even though the socket is
+      // still "usable" — so ensureConnected() won't reconnect, and every
+      // subsequent idle() returns instantly. That turns the caller's watch loop
+      // into a 100%-CPU busy spin (observed: an orphaned process burning a full
+      // core for days). Our IDLE calls are serialized per folder via _idleActive
+      // and awaited by the caller, so no legitimate IDLE can be in flight here —
+      // if the flag is set, it is stuck. Clear it so idle() actually enters IDLE
+      // and blocks.
+      if (idleClient.idling) {
+        this.log.warn("Clearing stuck IMAP IDLE state before re-entering IDLE", "IMAPService", {
+          folder,
+        });
+        idleClient.idling = false;
+      }
+
+      const idleStartedAt = Date.now();
       await client.idle();
+      const idleElapsedMs = Date.now() - idleStartedAt;
       const checkedAt = new Date().toISOString();
       const changed = events.length > 0;
+
+      // Defense in depth: a healthy IDLE blocks until a mailbox change or until
+      // ~timeoutMs elapses. If it returned near-instantly with no events, IDLE
+      // did not actually engage (stuck state, lost capability, or a half-open
+      // socket). Drop the connection so the next iteration reconnects a fresh
+      // client rather than spinning on repeated no-op idle() calls.
+      if (!changed && idleElapsedMs < MIN_HEALTHY_IDLE_MS) {
+        this.log.warn("IMAP IDLE returned without blocking; resetting connection", "IMAPService", {
+          folder,
+          idleElapsedMs,
+        });
+        await this.disconnect();
+      }
       this.lastIdleAt = checkedAt;
       this.lastIdleError = undefined;
       if (changed) {


### PR DESCRIPTION
## Problem

An orphaned server process can burn a full CPU core indefinitely. Observed in the wild: an instance launched Jul 28 was reparented to `launchd` and had accumulated **194 hours of CPU time** at ~100% of one core, while doing no useful work. Two independent defects combine to cause this.

### 1. The server never exits when its MCP client disconnects

`main()` only handles `SIGINT`/`SIGTERM` and never watches stdin. As a stdio MCP server, its only consumer is the parent process (e.g. Claude Desktop) on the other end of the pipe. When that parent exits it closes stdin — but the background-sync timer and IMAP connection keep the event loop alive, so the process is reparented to `launchd`/init and lingers forever.

**Fix:** exit as soon as the pipe closes — via `transport.onclose` and `process.stdin` `end`/`close`/`error` — with an idempotent shutdown guard.

### 2. The IMAP IDLE watch loop can busy-spin at 100% CPU

imapflow's `client.idle()` is a no-op early-return when its internal `idling` flag is already `true`:

```js
async idle() { if (!this.idling) { return await this.run('IDLE', this.maxIdleTime); } }
```

Proton Bridge can terminate an IDLE session server-side without our `DONE`, leaving imapflow's `idling` stuck `true` while the socket still reports `usable`. `ensureConnected()` therefore never reconnects, and every subsequent `idle()` returns instantly — turning the watch loop into a tight spin. Confirmed via `sample`: the hot stack is `AsyncFunctionAwaitResolveClosure → Date.prototype.toISOString` (the loop stamping `checkedAt` every iteration), with 0 idle wake-ups.

**Fix (defense in depth):**
- Clear the stuck `idling` flag before entering IDLE. Our IDLE calls are serialized per folder (`_idleActive`) and awaited by the caller, so no legitimate IDLE session is ever in flight at that point — a set flag is always stale.
- If `idle()` returns in under 500 ms with no events, drop the connection so the next iteration reconnects fresh instead of spinning.
- Add a 1 s per-iteration floor in the watch loop as a structural backstop, so the loop cannot busy-spin regardless of the underlying IMAP client's behavior.

## Changes

- `src/index.ts` — exit on stdin/transport close; idempotent shutdown.
- `src/services/simple-imap-service.ts` — clear stuck `idling`; reconnect on no-op IDLE return.
- `src/services/background-sync-service.ts` — minimum-duration floor per change-free watch iteration.

## Testing

- `npm run lint` (tsc) clean.
- `npm run test:unit` — all 45 tests pass.
- Verified end-to-end on macOS: killed the orphan; after rebuild + client restart, the server now exits cleanly with its parent (no orphan left behind) and idles at 0% CPU.