### PR TITLE
fix(claude-desktop): stop discarding wizard credentials and support lockfile-less installs

### DIFF
--- a/src/scripts/install-claude-desktop.ts
+++ b/src/scripts/install-claude-desktop.ts
@@ -162,13 +162,10 @@ export function buildClaudeDesktopServerConfig(
 ): { serverName: string; serverConfig: ClaudeDesktopServerConfig } {
   const cwd = resolve(options.runtimeDir || options.cwd || resolveSourceRepoRoot());
   const command = options.command || process.execPath;
-  const env =
-    options.includeEnv === false
-      ? undefined
-      : {
-          ...collectInstallEnv(),
-          ...(options.env ?? {}),
-        };
+  const env = {
+    ...(options.includeEnv === false ? {} : collectInstallEnv()),
+    ...(options.env ?? {}),
+  };
 
   return {
     serverName: options.serverName || DEFAULT_SERVER_NAME,
@@ -181,15 +178,32 @@ export function buildClaudeDesktopServerConfig(
   };
 }
 
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getNpmExecutable(): string {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
-async function installRuntimeDependencies(runtimeDir: string): Promise<void> {
+export function buildRuntimeInstallArgs(hasLockfile: boolean): string[] {
+  // `npm ci` requires a lockfile. npm never ships package-lock.json inside a published
+  // tarball, so a global/npx install has none and must fall back to `npm install`.
+  return hasLockfile
+    ? ["ci", "--omit=dev", "--ignore-scripts"]
+    : ["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"];
+}
+
+async function installRuntimeDependencies(runtimeDir: string, hasLockfile: boolean): Promise<void> {
   // On Windows, .cmd files (npm.cmd) require shell: true — execFile cannot run them directly.
   const shellOpts = process.platform === "win32" ? { shell: true } : {};
 
-  await execFileAsync(getNpmExecutable(), ["ci", "--omit=dev", "--ignore-scripts"], {
+  await execFileAsync(getNpmExecutable(), buildRuntimeInstallArgs(hasLockfile), {
     cwd: runtimeDir,
     env: process.env,
     ...shellOpts,
@@ -224,8 +238,17 @@ export async function prepareClaudeDesktopRuntime(options: InstallOptions = {}):
   await rm(join(runtimeDir, "dist"), { recursive: true, force: true });
   await cp(join(sourceCwd, "dist"), join(runtimeDir, "dist"), { recursive: true, force: true });
   await copyFile(join(sourceCwd, "package.json"), join(runtimeDir, "package.json"));
-  await copyFile(join(sourceCwd, "package-lock.json"), join(runtimeDir, "package-lock.json"));
-  await installRuntimeDependencies(runtimeDir);
+
+  // Only present when installing from a git checkout; published tarballs never contain it.
+  const lockfilePath = join(sourceCwd, "package-lock.json");
+  const hasLockfile = await pathExists(lockfilePath);
+  if (hasLockfile) {
+    await copyFile(lockfilePath, join(runtimeDir, "package-lock.json"));
+  } else {
+    await rm(join(runtimeDir, "package-lock.json"), { force: true });
+  }
+
+  await installRuntimeDependencies(runtimeDir, hasLockfile);
 
   return {
     runtimeDir,

--- a/test/install-claude-desktop.test.mjs
+++ b/test/install-claude-desktop.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { join } from "node:path";
 import {
   buildClaudeDesktopServerConfig,
+  buildRuntimeInstallArgs,
   collectInstallEnv,
   mergeClaudeDesktopConfig,
   resolveClaudeDesktopConfigPath,
@@ -81,4 +82,51 @@ test("resolveClaudeDesktopConfigPath honors explicit paths", () => {
 test("resolveClaudeDesktopRuntimeDir honors explicit paths", () => {
   const resolved = resolveClaudeDesktopRuntimeDir(join("/tmp", "proton-runtime"));
   assert.equal(resolved, "/tmp/proton-runtime");
+});
+
+test("buildClaudeDesktopServerConfig keeps explicitly provided env when includeEnv is false", () => {
+  // The setup wizard passes includeEnv:false (do not inherit ambient PROTONMAIL_*)
+  // together with the answers it collected. Those answers must survive.
+  const { serverConfig } = buildClaudeDesktopServerConfig({
+    runtimeDir: "/tmp/proton-runtime",
+    includeEnv: false,
+    env: {
+      PROTONMAIL_USERNAME: "user@example.com",
+      PROTONMAIL_PASSWORD: "bridge-password",
+    },
+  });
+
+  assert.equal(serverConfig.env.PROTONMAIL_USERNAME, "user@example.com");
+  assert.equal(serverConfig.env.PROTONMAIL_PASSWORD, "bridge-password");
+});
+
+test("buildClaudeDesktopServerConfig with includeEnv false still ignores ambient env", () => {
+  const previous = process.env.PROTONMAIL_USERNAME;
+  process.env.PROTONMAIL_USERNAME = "ambient@example.com";
+
+  try {
+    const { serverConfig } = buildClaudeDesktopServerConfig({
+      runtimeDir: "/tmp/proton-runtime",
+      includeEnv: false,
+    });
+
+    assert.equal(serverConfig.env, undefined);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PROTONMAIL_USERNAME;
+    } else {
+      process.env.PROTONMAIL_USERNAME = previous;
+    }
+  }
+});
+
+test("buildRuntimeInstallArgs uses npm ci only when a lockfile is present", () => {
+  assert.deepEqual(buildRuntimeInstallArgs(true), ["ci", "--omit=dev", "--ignore-scripts"]);
+  assert.deepEqual(buildRuntimeInstallArgs(false), [
+    "install",
+    "--omit=dev",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+  ]);
 });


### PR DESCRIPTION
Fixes #10.

`setup-claude-desktop` currently cannot produce a working Claude Desktop config. Two independent defects are involved; this PR addresses both and adds regression coverage.

## 1. The wizard discards the credentials it collects

`buildClaudeDesktopServerConfig` collapsed two separate concerns into one ternary:

```ts
const env =
  options.includeEnv === false
    ? undefined
    : { ...collectInstallEnv(), ...(options.env ?? {}) };
```

`runClaudeDesktopSetupWizard` passes `includeEnv: false` to mean *"do not inherit ambient `PROTONMAIL_*` variables"*, while also passing the answers it just collected as `options.env`. The short-circuit threw those answers away, so every wizard run wrote a server entry with no `env` block and the server died on startup:

```
ERROR [MCPServer] Fatal server error {"message":"Missing required environment variables or secret sources: PROTONMAIL_USERNAME and PROTONMAIL_PASSWORD."}
```

Now:

```ts
const env = {
  ...(options.includeEnv === false ? {} : collectInstallEnv()),
  ...(options.env ?? {}),
};
```

Ambient env is still suppressed when `includeEnv: false`; explicitly supplied env always survives. The existing `Object.keys(env).length > 0` guard means the no-env case still omits the key entirely, so nothing else changes.

## 2. `npm ci` requires a lockfile that published installs never have

`prepareClaudeDesktopRuntime` copied `package-lock.json` unconditionally and ran `npm ci`. npm never puts a lockfile in a published tarball, so a global or `npx` install crashed with `ENOENT` partway through staging:

```
ENOENT: no such file or directory, copyfile
  '/opt/homebrew/lib/node_modules/proton-mail-bridge-client/package-lock.json' -> ...
```

The lockfile is now treated as optional — copied and used with `npm ci` when present (git checkouts, keeping installs reproducible), with `npm install --omit=dev --ignore-scripts --no-audit --no-fund` as the fallback. A stale lockfile in the runtime directory is removed so a later lockfile-less install cannot pick it up. The `npm rebuild better-sqlite3` step is unchanged.

The install-args choice is factored into an exported `buildRuntimeInstallArgs(hasLockfile)` so it can be tested without shelling out to npm.

## Tests

Three new cases in `test/install-claude-desktop.test.mjs`:

- explicit `env` survives `includeEnv: false` (the credential bug)
- `includeEnv: false` still ignores ambient `PROTONMAIL_*` (guards the fix from over-correcting)
- `buildRuntimeInstallArgs` picks `ci` vs `install` correctly

Verified the first fails against `main` before the fix:

```
$ node -e "import('./dist/scripts/install-claude-desktop.js').then(m =>
    console.log(m.buildClaudeDesktopServerConfig({
      runtimeDir:'/tmp/rt', includeEnv:false,
      env:{PROTONMAIL_USERNAME:'user@example.com'}}).serverConfig.env))"
undefined
```

`npm run lint` and `npm run build` clean; full suite 120/120 passing on Node v26.8.1 / npm 11.19.0 (macOS arm64).

## Manual verification

With both fixes applied I staged a runtime and connected it to Claude Desktop against a live Proton Bridge: `initialize` returned `proton-mail-bridge-client 1.18.1`, `tools/list` returned 95 tools, and `get_folders` returned the real IMAP folder list.

One note not addressed here, in case it is worth a separate issue: the wizard writes `command` as `process.execPath`, which on a Homebrew Node is the version-pinned `/opt/homebrew/Cellar/node/<version>/bin/node`. That config breaks on the next `brew upgrade node` plus `brew cleanup`. Happy to send a follow-up if you would like it resolved to a stabler path.