### PR TITLE
Fix policy bypasses, index synchronization, and worker recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+
+## Unreleased
+
+- Enforce action allowlists and destructive confirmation across batch, thread, move, delete, generic flag, and direct CLI routes.
+- Preserve body-text search and reply references during flags-only index refreshes; remove indexed messages when a mailbox is observed empty.
+- Bound incremental backlogs, retain backfill progress, and continue discovering new mail and reconciling old state after full backfill completes.
+- Bound local indexing source reads to 1 MiB per message and 16 MiB per folder per cycle; full email reads/exports are unaffected.
+- Track send/snooze operation owners across processes; recover abandoned operations without risking automatic duplicates.
+- Pause snooze wakes under read-only or archive-disabled policy and prevent duplicate concurrent wake moves.
+- Align declared Node.js support with CI: 20, 22, and 24.
+
+
 All notable changes to this project are documented here.
 
 ## [2.0.0] — 2026-09-08

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![npm version](https://img.shields.io/npm/v/proton-mail-bridge-client?color=%236d4aff&label=npm)](https://www.npmjs.com/package/proton-mail-bridge-client)
 [![CI](https://github.com/googlarz/proton-mail-bridge-client/actions/workflows/ci.yml/badge.svg)](https://github.com/googlarz/proton-mail-bridge-client/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Node.js 18+](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
+[![Node.js 20, 22, 24](https://img.shields.io/badge/node-20%20%7C%2022%20%7C%2024-brightgreen)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet)](https://modelcontextprotocol.io)
 [![GitHub stars](https://img.shields.io/github/stars/googlarz/proton-mail-bridge-client?style=social)](https://github.com/googlarz/proton-mail-bridge-client)
@@ -55,7 +55,7 @@ Download: [proton.me/mail/bridge](https://proton.me/mail/bridge)
 
 > **Bridge password vs Proton password:** Proton Bridge generates a separate local password that is *not* your Proton account password. Find it inside the Bridge app under **Account → Copy password** (or similar — exact label varies by Bridge version). You'll need this for setup.
 
-**2. Node.js 18 or later** — `node --version` to check.
+**2. Node.js 20, 22, or 24** — `node --version` to check.
 
 **3. Your Bridge credentials** — from the Bridge app:
 - IMAP host/port (default: `127.0.0.1:1143`)
@@ -498,3 +498,15 @@ Bug reports and pull requests welcome: [github.com/googlarz/proton-mail-bridge-c
 ## License
 
 MIT
+
+### Synchronization bounds and worker recovery
+
+`sync_emails` respects `limitPerFolder` across the entire batch. Incremental sync advances through a backlog in bounded steps and reconciles deletions in the scanned range. `full:true` shares the batch between new mail and historical backfill, then cycles through history again to refresh old flags and deletions. Large folders need multiple cycles; a successful cycle does not mean every message has been refreshed. An observed empty folder is cleared from the index immediately.
+
+Local body/attachment-text indexing is best effort: source reads are capped at 1 MiB per message and 16 MiB per folder per cycle, divided across the batch. Text beyond these bounds is not guaranteed searchable. Reading or exporting the original email still retrieves its full source.
+
+Snooze wakes obey the current read-only and archive-action policies. Restricted items stay pending with `pausedReason` and resume when allowed, without exhausting retries. Concurrent cancel requests return `waking` while the winning move is in progress.
+
+Send and snooze workers persist an owner PID and a unique operation token. A second process leaves a live owner's operation alone. Operations abandoned by a dead owner are marked failed with an unknown outcome and are not automatically retried. Restart existing MCP processes when updating so all workers use the same ownership protocol.
+
+The action allowlist applies to single-message, bulk, thread, and generic flag routes. Arbitrary moves require `move`; permanent deletions and adding `\Deleted` require `delete`. Under destructive confirmation mode, use `--confirmed` with CLI `batch` and `thread-action` deletes, or `confirmed:true` in tool arguments. Direct CLI reply/forward also honor confirmation and outbound-recipient restrictions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "20.x || 22.x || 24.x"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proton-mail-bridge-client",
   "version": "2.0.0",
-  "description": "Proton Mail Bridge Client — full-featured CLI and Claude Desktop MCP for Proton Mail via Proton Bridge. Read, search, send, draft, archive, manage folders, and more.",
+  "description": "Proton Mail Bridge Client \u2014 full-featured CLI and Claude Desktop MCP for Proton Mail via Proton Bridge. Read, search, send, draft, archive, manage folders, and more.",
   "mcpName": "io.github.googlarz/proton-mail-bridge-client",
   "type": "module",
   "packageManager": "npm@10.9.3",
@@ -67,7 +67,7 @@
     "url": "https://github.com/googlarz/proton-mail-bridge-client/issues"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "20.x || 22.x || 24.x"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { buildConfigFromEnv, createServer, withAudit } from "./index.js";
 import { isMainModule } from "./is-main.js";
 import { SimpleIMAPService } from "./services/simple-imap-service.js";
 import type { EmailAddress, EmailDetail, EmailSummary, ProtonMailConfig, SearchEmailsInput } from "./types/index.js";
-import { ensureDestructiveConfirmed, ensureEmailActionAllowed, ensureMailboxWriteAllowed, ensureSendAllowed, sanitizeRuntimeConfig } from "./utils/runtime-policy.js";
+import { ensureDestructiveConfirmed, ensureEmailActionAllowed, ensureMailboxWriteAllowed, ensureSendAllowed, ensureToolActionAllowed, ensureOutboundRecipientsAllowed, sanitizeRuntimeConfig } from "./utils/runtime-policy.js";
 import { isValidEmail, lowerCaseAddress, parseEmails, ensureValidEmails } from "./utils/helpers.js";
 import { getClaudeDesktopInstallStatus } from "./scripts/check-claude-desktop.js";
 import { installClaudeDesktopConfig } from "./scripts/install-claude-desktop.js";
@@ -896,7 +896,7 @@ async function runMove(parsed: ParsedCliArgs): Promise<void> {
   if (!targetFolder) throw new Error("move requires a target folder as a second argument or --folder");
   const wantJson = isTruthyFlag(parsed.flags.json);
   await withServices(async ({ config, imapService, auditService }) => {
-    ensureMailboxWriteAllowed(config.runtime);
+    ensureToolActionAllowed(config.runtime, "move_email", { confirmed: isTruthyFlag(parsed.flags.confirmed) });
     // Found live: every write command in this file called the service
     // directly, so none of them ever produced an audit.log entry — unlike
     // the identical action through an MCP tool call, which withAudit always
@@ -984,7 +984,7 @@ async function runDelete(parsed: ParsedCliArgs): Promise<void> {
   if (!emailId) throw new Error("delete requires an emailId");
   const wantJson = isTruthyFlag(parsed.flags.json);
   await withServices(async ({ config, imapService, auditService }) => {
-    ensureMailboxWriteAllowed(config.runtime);
+    ensureToolActionAllowed(config.runtime, "delete_email", { confirmed: isTruthyFlag(parsed.flags.confirmed) });
     // Found live: this called the service directly, bypassing the MCP
     // tool layer's ensureDestructiveConfirmed entirely — with
     // PROTONMAIL_CONFIRM_DESTRUCTIVE=true, `tool delete_email` correctly
@@ -1104,8 +1104,10 @@ async function runReply(parsed: ParsedCliArgs): Promise<void> {
   const wantJson = isTruthyFlag(parsed.flags.json);
   await withServices(async ({ config, smtpService, imapService, auditService }) => {
     ensureSendAllowed(config.runtime);
+    ensureDestructiveConfirmed(config.runtime, isTruthyFlag(parsed.flags.confirmed), "Send email");
     const detail = await imapService.getEmailById(emailId);
     const recipients = getReplyRecipients(detail, config.smtp.username, replyAll);
+    ensureOutboundRecipientsAllowed(config.runtime, config.smtp.username, [...recipients.to, ...recipients.cc]);
     if (recipients.to.length === 0) throw new Error("Unable to infer reply recipient.");
     const result = await withAudit(auditService, "reply_to_email", { emailId, replyAll }, () =>
       smtpService.sendEmail({
@@ -1138,7 +1140,9 @@ async function runForward(parsed: ParsedCliArgs): Promise<void> {
   const wantJson = isTruthyFlag(parsed.flags.json);
   await withServices(async ({ config, smtpService, imapService, auditService }) => {
     ensureSendAllowed(config.runtime);
+    ensureDestructiveConfirmed(config.runtime, isTruthyFlag(parsed.flags.confirmed), "Send email");
     ensureValidEmails(to, "to");
+    ensureOutboundRecipientsAllowed(config.runtime, config.smtp.username, to);
     const detail = await imapService.getEmailById(emailId);
     const result = await withAudit(auditService, "forward_email", { emailId, to }, () =>
       smtpService.sendEmail({
@@ -1180,7 +1184,7 @@ async function runDeleteFolder(parsed: ParsedCliArgs): Promise<void> {
   if (!path) throw new Error("delete-folder requires a path argument");
   const wantJson = isTruthyFlag(parsed.flags.json);
   await withServices(async ({ config, imapService, auditService }) => {
-    ensureMailboxWriteAllowed(config.runtime);
+    ensureToolActionAllowed(config.runtime, "delete_folder", { confirmed: isTruthyFlag(parsed.flags.confirmed) });
     // Same bypass as runDelete's identical gap — see its comment.
     ensureDestructiveConfirmed(config.runtime, isTruthyFlag(parsed.flags.confirmed), `Permanently delete folder and all messages in it: ${path}`);
     const result = await withAudit(auditService, "delete_folder", { path }, () => imapService.deleteFolder(path));
@@ -1387,6 +1391,7 @@ async function runThreadAction(parsed: ParsedCliArgs): Promise<void> {
       arguments: {
         threadId,
         action,
+        confirmed: isTruthyFlag(parsed.flags.confirmed) || undefined,
         targetFolder: getStringFlag(parsed.flags, "folder"),
         unreadOnly: isTruthyFlag(parsed.flags["unread-only"]) || undefined,
         dryRun: isTruthyFlag(parsed.flags["dry-run"]) || undefined,
@@ -1408,6 +1413,7 @@ async function runBatch(parsed: ParsedCliArgs): Promise<void> {
       arguments: {
         emailIds,
         action,
+        confirmed: isTruthyFlag(parsed.flags.confirmed) || undefined,
         targetFolder: getStringFlag(parsed.flags, "folder"),
         dryRun: isTruthyFlag(parsed.flags["dry-run"]) || undefined,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -804,7 +804,7 @@ const TOOLS = [
   },
   {
     name: "cancel_snooze",
-    description: "Wake a snoozed email immediately, moving it back to its original folder before wakeAt. No effect (throws) if the snooze has already woken or was already canceled.",
+    description: "Wake a snoozed email immediately, moving it back to its original folder before wakeAt. Returns the existing status if already resolved; returns waking when another request owns the move.",
     annotations: { destructiveHint: false },
     inputSchema: {
       type: "object",
@@ -928,6 +928,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
+        confirmed: { type: "boolean", description: "Confirm adding the Deleted flag when destructive confirmation is enabled." },
         emailId: { type: "string", description: "Composite email id in FOLDER::UID format." },
         flagsToAdd: {
           type: "array",
@@ -1033,6 +1034,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
+        confirmed: { type: "boolean", description: "Confirm adding the Deleted flag when destructive confirmation is enabled." },
         emailIds: { type: "array", items: { type: "string" }, description: "Explicit email IDs. XOR with match." },
         match: { type: "object", description: "Search criteria. XOR with emailIds.", properties: { from: { type: "string" }, subject: { type: "string" }, text: { type: "string" }, since: { type: "string" }, before: { type: "string" }, isRead: { type: "boolean" }, isStarred: { type: "boolean" } } },
         folder: { type: "string", description: "Source folder (required with match)." },
@@ -1114,6 +1116,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
+        confirmed: { type: "boolean", description: "Confirm adding the Deleted flag when destructive confirmation is enabled." },
         messageId: { type: "string", description: "RFC 5322 Message-ID." },
         flagsToAdd: { type: "array", items: { type: "string" } },
         flagsToRemove: { type: "array", items: { type: "string" } },
@@ -1345,7 +1348,7 @@ const TOOLS = [
   },
   {
     name: "sync_emails",
-    description: "Incrementally sync email metadata from IMAP into the local SQLite index, using stored checkpoints to avoid re-fetching already-indexed messages. Use before calling search_indexed_emails or get_threads when the index may be stale. The default incremental sync only ever adds/updates recent messages — it never notices a message that was archived, trashed, or moved out of the synced folder by any client, so search/thread/digest tools can keep showing a message as still present indefinitely. Set full:true (per folder — sync each folder you want cleaned up) to also detect and prune those, in addition to fetching a larger sample. Prefer run_background_sync to trigger the scheduled sync cycle (also incremental-only by default; see PROTONMAIL_AUTO_SYNC_FULL).",
+    description: "Sync IMAP metadata into the local SQLite index in bounded batches. Incremental sync advances new mail and reconciles its scanned UID range. full:true also cycles through historical ranges to backfill and refresh older flags/deletions, while continuing to discover new mail. Repeat for large folders; one call is not a whole-mailbox snapshot. Empty mailboxes are cleared immediately. Body/attachment-text indexing is best effort, capped at 1 MiB source per message and 16 MiB per folder per cycle. Prefer run_background_sync for the configured scheduled cycle.",
     annotations: { destructiveHint: false },
     inputSchema: {
       type: "object",
@@ -1702,6 +1705,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
+        confirmed: { type: "boolean", description: "Confirm adding the Deleted flag when destructive confirmation is enabled." },
         raw: { type: "string", description: "Full raw RFC822 message source (the .eml file content) as a UTF-8 string. Use rawBase64 instead for non-UTF-8 content. Exactly one of raw/rawBase64 is required." },
         rawBase64: { type: "string", description: "Full raw RFC822 message source (the .eml file content), base64-encoded, for byte-exact import of non-UTF-8 content. Exactly one of raw/rawBase64 is required." },
         targetFolder: { type: "string", description: "Destination folder. Defaults to INBOX." },

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import { logger } from "./utils/logger.js";
 import {
   ensureDestructiveConfirmed,
   ensureEmailActionAllowed,
+  ensureToolActionAllowed,
   ensureMailboxWriteAllowed,
   ensureOutboundRecipientsAllowed,
   ensureRemoteDraftSyncAllowed,
@@ -1167,6 +1168,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
+        confirmed: { type: "boolean", description: "Confirm permanent deletion when destructive confirmation is enabled." },
         emailIds: {
           oneOf: [
             {
@@ -1204,11 +1206,12 @@ const TOOLS = [
   {
     name: "apply_thread_action",
     description:
-      "Apply a reversible mailbox action to every message in a normalized thread at once. Use when you want to act on a full thread identified by threadId (e.g. archive or mark-read an entire conversation). Supports dryRun, unreadOnly to scope impact, and syncBefore to refresh the index first. Prefer batch_email_action when you have explicit emailIds rather than a threadId.",
+      "Apply a mailbox action (including permanent delete) to every message in a normalized thread at once. Use when you want to act on a full thread identified by threadId (e.g. archive or mark-read an entire conversation). Supports dryRun, unreadOnly to scope impact, and syncBefore to refresh the index first. Prefer batch_email_action when you have explicit emailIds rather than a threadId.",
     annotations: { destructiveHint: true },
     inputSchema: {
       type: "object",
       properties: {
+        confirmed: { type: "boolean", description: "Confirm permanent deletion when destructive confirmation is enabled." },
         threadId: { type: "string", description: "Thread id from get_threads or get_actionable_threads." },
         action: {
           type: "string",
@@ -3283,6 +3286,7 @@ export function createServer(
     logger.debug("Handling tool call", "MCPServer", { name, argKeys: Object.keys(args || {}) });
 
     try {
+      ensureToolActionAllowed(config.runtime, name, args);
       switch (name) {
         case "send_email": {
           ensureDestructiveConfirmed(config.runtime, normalizeBoolean(args.confirmed, false), `Send email to ${String(args.to ?? "?")} — "${String(args.subject ?? "?")}"`);

--- a/src/services/delivery-queue-service.ts
+++ b/src/services/delivery-queue-service.ts
@@ -3,6 +3,7 @@ import { copyFileSync } from "node:fs";
 import { mkdir, readFile, readdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { DeliveryQueueKind, DeliveryQueueRecord, ProtonMailConfig, SendEmailInput } from "../types/index.js";
+import { createOperationClaim, isAbandonedClaim } from "../utils/operation-claim.js";
 import { withFileLock } from "../utils/file-lock.js";
 import { ensureOutboundRecipientsAllowed, ensureSendAllowed } from "../utils/runtime-policy.js";
 import { logger, type Logger } from "../utils/logger.js";
@@ -60,7 +61,12 @@ export class DeliveryQueueService {
     // A "sending" record left over from a process that died mid-send has an
     // unknown outcome — resolve those before the catch-up pass can touch
     // anything, so we never guess and double-send.
-    await this.recoverInterruptedSends();
+    try {
+      await this.recoverInterruptedSends();
+    } catch (error) {
+      this.started = false;
+      throw error;
+    }
     // Catch-up pass immediately, then check periodically. Fire-and-forget,
     // but guarded: an unhandled rejection here (e.g. a file-lock acquisition
     // timeout) would otherwise propagate to index.ts's global handler and
@@ -152,6 +158,7 @@ export class DeliveryQueueService {
   // so a send already in flight can no longer be reported as canceled while
   // it actually goes out, and no item can be sent twice.
   async checkDue(): Promise<{ sent: number; failed: number }> {
+    await this.recoverInterruptedSends();
     const now = Date.now();
     const dueIds = (await this.list())
       .filter((item) => item.status === "pending" && new Date(item.sendAt).getTime() <= now)
@@ -165,6 +172,7 @@ export class DeliveryQueueService {
         const record = store.items[id];
         if (!record || record.status !== "pending") return undefined;
         record.status = "sending";
+        record.claim = createOperationClaim();
         await this.save(store);
         return record;
       });
@@ -195,8 +203,9 @@ export class DeliveryQueueService {
         await this.withLock(async () => {
           const store = await this.loadUnlocked();
           const record = store.items[id];
-          if (record && record.status === "sending") {
+          if (record && record.status === "sending" && record.claim?.token === claimed.claim?.token) {
             record.status = "sent";
+            delete record.claim;
             record.sentAt = new Date().toISOString();
             record.sentMessageId = result.messageId;
             await this.save(store);
@@ -220,8 +229,9 @@ export class DeliveryQueueService {
         await this.withLock(async () => {
           const store = await this.loadUnlocked();
           const record = store.items[id];
-          if (record && record.status === "sending") {
+          if (record && record.status === "sending" && record.claim?.token === claimed.claim?.token) {
             record.status = "failed";
+            delete record.claim;
             record.failureReason = message;
             await this.save(store);
           }
@@ -259,18 +269,16 @@ export class DeliveryQueueService {
     return changed;
   }
 
-  // Runs once at start(), before the catch-up checkDue() pass. A record
-  // stuck in "sending" means the previous process died between claiming the
-  // item and recording the outcome — whether the SMTP call actually
-  // completed is unknown, so it is never auto-resent. It is marked "failed"
-  // with a reason that says so explicitly, for the caller to verify by hand.
+  // Recover only abandoned owners, at startup and on subsequent ticks.
+  // SMTP outcomes after a crash are unknown, so these items are never resent.
   private async recoverInterruptedSends(): Promise<void> {
     await this.withLock(async () => {
       const store = await this.loadUnlocked();
       let changed = false;
       for (const record of Object.values(store.items)) {
-        if (record.status !== "sending") continue;
+        if (record.status !== "sending" || !isAbandonedClaim(record.claim)) continue;
         record.status = "failed";
+        delete record.claim;
         record.failureReason = "Interrupted by a server restart while sending — delivery outcome is unknown. Not auto-resent; check the mailbox's Sent folder to confirm whether it actually went out before resending manually.";
         changed = true;
       }
@@ -342,15 +350,7 @@ export class DeliveryQueueService {
     }
   }
 
-  // ponytail: withLock only serializes calls within this process — two
-  // separate processes sharing this dataDir (e.g. a CLI `cancel-send` racing
-  // this server's own checkDue()) can still interleave load-modify-save and
-  // lose one side's update. No OS-level lock (flock/lockfile) is taken. A
-  // bespoke cross-process lockfile trades a rare millisecond-window lost
-  // update for a worse failure mode (a crash mid-lock leaves a stale lockfile
-  // that blocks every future send). Real upgrade path if this ever matters:
-  // move this JSON store into the SQLite index already used elsewhere
-  // (better-sqlite3), which has real cross-process locking for free.
+  // Called while holding the cross-process file lock. Rename is atomic.
   private async save(store: DeliveryQueueFile): Promise<void> {
     await mkdir(dirname(this.queuePath), { recursive: true, mode: 0o700 });
     const tempPath = `${this.queuePath}.tmp`;

--- a/src/services/local-index-service.ts
+++ b/src/services/local-index-service.ts
@@ -1367,13 +1367,13 @@ export class LocalIndexService {
     const insertFts = db.prepare(`
       INSERT INTO messages_fts (
         email_id, subject, preview, folder, labels, participants, attachment_names
-      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ) SELECT ?, ?, preview, ?, ?, ?, ? FROM messages WHERE email_id = ?
     `);
     const setMetadata = db.prepare(`
       INSERT INTO metadata (key, value) VALUES (?, ?)
       ON CONFLICT(key) DO UPDATE SET value = excluded.value
     `);
-    const getStoredSyncState = db.prepare(`SELECT uid_validity FROM sync_state WHERE folder = ?`);
+    const getStoredSyncState = db.prepare(`SELECT uid_validity, backfilled_to_uid FROM sync_state WHERE folder = ?`);
     const deleteFtsForFolder = db.prepare(`
       DELETE FROM messages_fts
       WHERE email_id IN (SELECT email_id FROM messages WHERE folder = ?)
@@ -1395,6 +1395,10 @@ export class LocalIndexService {
         const stored = getStoredSyncState.get(folderStat.folder) as { uid_validity?: string | null } | undefined;
         const storedUidValidity = stored?.uid_validity ?? null;
         const serverUidValidity = folderStat.uidValidity ?? null;
+        if (folderStat.strategy === "empty" && folderStat.total === 0) {
+          deleteFtsForFolder.run(folderStat.folder);
+          deleteMessagesForFolder.run(folderStat.folder);
+        }
         if (storedUidValidity && serverUidValidity && storedUidValidity !== serverUidValidity) {
           this.log.warn(
             `UIDVALIDITY changed for folder ${folderStat.folder}, clearing local index.`,
@@ -1431,6 +1435,7 @@ export class LocalIndexService {
 
       for (const folderStat of input.folderStats) {
         const resetCheckpoint = foldersWithResetCheckpoint.has(folderStat.folder);
+        const previous = getStoredSyncState.get(folderStat.folder) as { backfilled_to_uid?: number } | undefined;
         upsertSyncState.run({
           folder: folderStat.folder,
           uid_validity: resetCheckpoint ? null : folderStat.uidValidity ?? null,
@@ -1445,7 +1450,8 @@ export class LocalIndexService {
           changed: folderStat.changed ? 1 : 0,
           fetched: folderStat.fetched ?? null,
           total: folderStat.total ?? null,
-          backfilled_to_uid: resetCheckpoint ? null : folderStat.backfilledToUid ?? null,
+          backfilled_to_uid: resetCheckpoint || folderStat.strategy === "empty"
+            ? null : folderStat.backfilledToUid ?? previous?.backfilled_to_uid ?? null,
         });
       }
 
@@ -1483,11 +1489,11 @@ export class LocalIndexService {
         insertFts.run(
           email.id,
           email.subject,
-          email.preview ?? "",
           email.folder,
           search.labels,
           search.participants,
           search.attachmentNames,
+          email.id,
         );
       }
 

--- a/src/services/local-index-service.ts
+++ b/src/services/local-index-service.ts
@@ -578,7 +578,7 @@ export class LocalIndexService {
   }): Promise<LocalIndexStatus> {
     const db = await this.ensureDb();
     const ownerEmail = lowerCaseAddress(this.config.smtp.username);
-    this.applySnapshot(db, input, ownerEmail, input.folderStats.some((entry) => entry.strategy === "full"));
+    this.applySnapshot(db, input, ownerEmail, input.folderStats.some((entry) => entry.rangeStartUid !== undefined || entry.scannedRanges?.length));
     return this.getStatus();
   }
 
@@ -1320,7 +1320,7 @@ export class LocalIndexService {
         seq = excluded.seq,
         message_id = excluded.message_id,
         in_reply_to = excluded.in_reply_to,
-        references_json = excluded.references_json,
+        references_json = CASE WHEN excluded.preview IS NULL THEN messages.references_json ELSE excluded.references_json END,
         thread_id = excluded.thread_id,
         subject = excluded.subject,
         from_json = excluded.from_json,
@@ -1527,26 +1527,19 @@ export class LocalIndexService {
             AND uid BETWEEN ? AND ?
             AND uid NOT IN (SELECT uid FROM temp_snapshot_uids)
         `);
-        const rangesByFullSyncFolder = new Map<string, { uids: Set<number>; rangeStartUid: number; rangeEndUid: number }>();
         for (const folderStat of input.folderStats) {
-          if (folderStat.strategy === "full" && folderStat.rangeStartUid !== undefined && folderStat.rangeEndUid !== undefined) {
-            rangesByFullSyncFolder.set(folderStat.folder, {
-              uids: new Set<number>(),
-              rangeStartUid: folderStat.rangeStartUid,
-              rangeEndUid: folderStat.rangeEndUid,
-            });
-          }
-        }
-        for (const email of input.emails) {
-          rangesByFullSyncFolder.get(email.folder)?.uids.add(email.uid);
-        }
-        for (const [folder, range] of rangesByFullSyncFolder) {
+          const ranges = folderStat.scannedRanges ?? (
+            folderStat.rangeStartUid !== undefined && folderStat.rangeEndUid !== undefined
+              ? [{ startUid: folderStat.rangeStartUid, endUid: folderStat.rangeEndUid }] : []);
+          if (ranges.length === 0) continue;
           clearSnapshotUidTable.run();
-          for (const uid of range.uids) {
-            insertSnapshotUid.run(uid);
+          for (const email of input.emails) {
+            if (email.folder === folderStat.folder) insertSnapshotUid.run(email.uid);
           }
-          deleteExpungedFts.run(folder, range.rangeStartUid, range.rangeEndUid);
-          deleteExpungedMessages.run(folder, range.rangeStartUid, range.rangeEndUid);
+          for (const range of ranges) {
+            deleteExpungedFts.run(folderStat.folder, range.startUid, range.endUid);
+            deleteExpungedMessages.run(folderStat.folder, range.startUid, range.endUid);
+          }
         }
         clearSnapshotUidTable.run();
       }

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2591,6 +2591,12 @@ export class SimpleIMAPService {
           const enriched = message.source
             ? this.enrichSummaryFromParsed(summary, await this.parseSource(message.source), input.includeAttachmentText)
             : summary;
+          if (message.source && (message.size ?? Number.POSITIVE_INFINITY) > message.source.length) {
+            // A partial MIME body cannot supply authoritative attachment sizes
+            // or a complete attachment list; keep the server's BODYSTRUCTURE.
+            enriched.attachments = summary.attachments;
+            enriched.hasAttachments = summary.hasAttachments;
+          }
           emails.push(enriched);
           this.messageCache.set(enriched.id, enriched);
           this.capMessageCache();

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -67,15 +67,6 @@ const FETCH_INDEX_QUERY = {
   bodyStructure: true,
 } as const;
 
-// Indexing needs the message source to populate preview/attachmentText for FTS body
-// search — collectFolderForIndex previously used FETCH_INDEX_QUERY (no source), so
-// every indexed message's preview and attachmentText silently stayed undefined and
-// search_indexed_emails' body search always returned nothing.
-const FETCH_INDEX_DETAIL_QUERY = {
-  ...FETCH_INDEX_QUERY,
-  source: true,
-} as const;
-
 const MAX_ATTACHMENT_TEXT_BYTES = 512_000;
 // A healthy IMAP IDLE blocks until a mailbox change or the requested timeout.
 // If client.idle() returns faster than this with no events, IDLE never actually
@@ -280,6 +271,8 @@ export interface FolderSyncPlan {
   startUid?: number;
   endUid?: number;
   highestKnownUid: number;
+  checkpointHighestUid?: number;
+  refreshRange?: { startUid: number; endUid: number };
   backfilledToUid?: number;
 }
 
@@ -305,39 +298,30 @@ export function planFolderSync(input: {
   }
 
   if (input.full) {
-    // Without backfill, every full:true call recomputed the same "newest N
-    // UIDs" window from scratch, so repeated calls could never reach
-    // anything older — found live: two consecutive full syncs of a
-    // 22k-message folder both fetched the identical top 500 UIDs, and the
-    // other ~22k older messages were permanently unreachable. Continue from
-    // where the last full/backfill call left off instead, walking the
-    // window backward through history one call at a time.
-    const uidValidityMatches =
-      !input.checkpoint?.uidValidity || !input.uidValidity || input.checkpoint.uidValidity === input.uidValidity;
-    const priorFloor = uidValidityMatches ? input.checkpoint?.backfilledToUid : undefined;
-
-    if (priorFloor !== undefined && priorFloor <= 1) {
-      // Already backfilled all the way back to UID 1 in a previous call —
-      // nothing older left to fetch.
-      return {
-        folder: input.folder,
-        strategy: "full",
-        changed: false,
-        highestKnownUid,
-        backfilledToUid: priorFloor,
-      };
-    }
-
-    const endUid = priorFloor !== undefined ? priorFloor - 1 : highestKnownUid;
-    const startUid = Math.max(1, endUid - input.limit + 1);
+    const valid = !input.checkpoint?.uidValidity || !input.uidValidity
+      || input.checkpoint.uidValidity === input.uidValidity;
+    const previousHigh = valid && (input.checkpoint?.highestUid ?? 0) <= highestKnownUid
+      ? input.checkpoint?.highestUid : undefined;
+    const priorFloor = valid && previousHigh !== undefined
+      ? input.checkpoint?.backfilledToUid : (valid && !input.checkpoint?.highestUid ? input.checkpoint?.backfilledToUid : undefined);
+    // Reserve part of each full-sync batch for new mail while the rest walks
+    // history. Once history reaches UID 1, cycle again to reconcile old flags
+    // and deletions instead of permanently stopping refreshes.
+    const newCount = previousHigh ? highestKnownUid - previousHigh : 0;
+    const refreshCount = Math.min(newCount, Math.ceil(input.limit / 2));
+    const refreshRange = refreshCount > 0 && previousHigh !== undefined
+      ? { startUid: previousHigh + 1, endUid: previousHigh + refreshCount } : undefined;
+    const historyBudget = input.limit - refreshCount;
+    const endUid = priorFloor !== undefined && priorFloor > 1
+      ? priorFloor - 1 : (previousHigh ?? highestKnownUid);
+    const startUid = Math.max(1, endUid - historyBudget + 1);
     return {
-      folder: input.folder,
-      strategy: "full",
-      changed: true,
-      startUid,
-      endUid,
-      highestKnownUid,
-      backfilledToUid: startUid,
+      folder: input.folder, strategy: "full", changed: true, highestKnownUid,
+      startUid: historyBudget > 0 ? startUid : refreshRange?.startUid,
+      endUid: historyBudget > 0 ? endUid : refreshRange?.endUid,
+      refreshRange: historyBudget > 0 ? refreshRange : undefined,
+      checkpointHighestUid: refreshRange?.endUid ?? previousHigh ?? highestKnownUid,
+      backfilledToUid: historyBudget > 0 ? startUid : priorFloor,
     };
   }
 
@@ -367,18 +351,18 @@ export function planFolderSync(input: {
     };
   }
 
-  const overlap = Math.min(input.limit, Math.max(25, Math.min(100, Math.ceil(input.limit / 2))));
-  const changed =
-    highestKnownUid > (input.checkpoint.highestUid ?? 0) ||
-    uidNext !== (input.checkpoint.uidNext ?? uidNext) ||
-    input.exists !== (input.checkpoint.total ?? input.exists);
+  const newCount = highestKnownUid - input.checkpoint.highestUid;
+  const overlap = Math.min(Math.max(0, input.limit - Math.min(newCount, input.limit)),
+    Math.max(25, Math.min(100, Math.ceil(input.limit / 2))));
+  const startUid = Math.max(1, input.checkpoint.highestUid - overlap + 1);
+  const endUid = Math.min(highestKnownUid, startUid + input.limit - 1);
+  const changed = newCount > 0 || input.exists !== (input.checkpoint.total ?? input.exists);
   return {
     folder: input.folder,
     strategy: changed ? "incremental" : "incremental_window",
-    changed,
-    startUid: Math.max(1, Math.min(highestKnownUid, input.checkpoint.highestUid) - overlap + 1),
-    endUid: highestKnownUid,
-    highestKnownUid,
+    changed, startUid, endUid, highestKnownUid,
+    checkpointHighestUid: endUid,
+    backfilledToUid: input.checkpoint.backfilledToUid,
   };
 }
 
@@ -2590,37 +2574,33 @@ export class SimpleIMAPService {
         };
       }
 
-      // On an unchanged incremental window (nothing new, checkpoint still matches),
-      // the overlap range only needs a flags refresh — IMAP content for a given UID
-      // never changes, so re-fetching source and re-parsing preview/attachmentText
-      // on every idle sync tick is pure waste. recordSnapshot's upsert preserves the
-      // existing preview/attachment_text via COALESCE when they come back unset here.
       const needsFullDetail = plan.strategy !== "incremental_window";
-      const fetchQuery = needsFullDetail ? FETCH_INDEX_DETAIL_QUERY : FETCH_INDEX_QUERY;
-
+      const ranges = [{ startUid: plan.startUid, endUid: plan.endUid },
+        ...(plan.refreshRange ? [plan.refreshRange] : [])];
       const emails: EmailSummary[] = [];
-      for await (const message of client.fetch(`${plan.startUid}:${plan.endUid}`, fetchQuery, { uid: true })) {
-        const summary = this.toSummary(folder, message);
-        const enriched = message.source
-          ? this.enrichSummaryFromParsed(summary, await this.parseSource(message.source), input.includeAttachmentText)
-          : summary;
-        emails.push(enriched);
-        this.messageCache.set(enriched.id, enriched);
+      // Fetch metadata first, then bounded source fragments outside the fetch
+      // iterator (issuing another IMAP command inside it would deadlock).
+      for (const range of ranges) {
+        for await (const message of client.fetch(`${range.startUid}:${range.endUid}`, FETCH_INDEX_QUERY, { uid: true })) {
+          emails.push(this.toSummary(folder, message));
+        }
+      }
+      let remainingSourceBytes = 16 * 1024 * 1024;
+      for (let i = 0; i < emails.length; i++) {
+        let summary = emails[i];
+        if (needsFullDetail && remainingSourceBytes > 0) {
+          const maxLength = Math.min(1024 * 1024, Math.floor(remainingSourceBytes / (emails.length - i)));
+          const detail = await client.fetchOne(String(summary.uid), { uid: true, source: { start: 0, maxLength } }, { uid: true });
+          if (detail && detail.source) {
+            remainingSourceBytes -= detail.source.length;
+            summary = this.enrichSummaryFromParsed(summary, await this.parseSource(detail.source), input.includeAttachmentText);
+            emails[i] = summary;
+          }
+        }
+        this.messageCache.set(summary.id, summary);
         this.capMessageCache();
       }
-
-      // A backfill-continuation window's endUid is an older UID than the
-      // mailbox's true current top (highestKnownUid) — only derive
-      // highestUid from what was actually fetched when this window reaches
-      // that top; otherwise keep the existing checkpoint's highestUid
-      // unchanged; using this batch's (much lower) fetched UIDs here would
-      // silently roll the incremental-sync high-water-mark backward and
-      // make every subsequent incremental sync think a huge amount of
-      // "new" mail exists again.
-      const reachesTop = plan.endUid === plan.highestKnownUid;
-      const highestUid = reachesTop
-        ? emails.reduce((max, email) => Math.max(max, email.uid), 0) || plan.highestKnownUid
-        : (input.checkpoint?.highestUid ?? plan.highestKnownUid);
+      const highestUid = plan.checkpointHighestUid ?? plan.endUid;
       return {
         checkpoint: {
           folder,
@@ -2638,6 +2618,7 @@ export class SimpleIMAPService {
           total: exists,
           rangeStartUid: plan.startUid,
           rangeEndUid: plan.endUid,
+          scannedRanges: ranges,
           backfilledToUid: plan.backfilledToUid,
         },
         emails,

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -298,12 +298,13 @@ export function planFolderSync(input: {
   }
 
   if (input.full) {
-    const valid = !input.checkpoint?.uidValidity || !input.uidValidity
-      || input.checkpoint.uidValidity === input.uidValidity;
-    const previousHigh = valid && (input.checkpoint?.highestUid ?? 0) <= highestKnownUid
-      ? input.checkpoint?.highestUid : undefined;
-    const priorFloor = valid && previousHigh !== undefined
-      ? input.checkpoint?.backfilledToUid : (valid && !input.checkpoint?.highestUid ? input.checkpoint?.backfilledToUid : undefined);
+    const reset = Boolean(input.checkpoint?.uidValidity && input.uidValidity
+      && input.checkpoint.uidValidity !== input.uidValidity)
+      || (input.checkpoint?.highestUid ?? 0) > highestKnownUid;
+    const previousHigh = !reset && input.checkpoint?.highestUid
+      ? input.checkpoint.highestUid : undefined;
+    const priorFloor = !reset && input.checkpoint?.highestUid !== 0
+      ? input.checkpoint?.backfilledToUid : undefined;
     // Reserve part of each full-sync batch for new mail while the rest walks
     // history. Once history reaches UID 1, cycle again to reconcile old flags
     // and deletions instead of permanently stopping refreshes.

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2579,27 +2579,22 @@ export class SimpleIMAPService {
       const ranges = [{ startUid: plan.startUid, endUid: plan.endUid },
         ...(plan.refreshRange ? [plan.refreshRange] : [])];
       const emails: EmailSummary[] = [];
-      // Fetch metadata first, then bounded source fragments outside the fetch
-      // iterator (issuing another IMAP command inside it would deadlock).
+      const plannedCount = ranges.reduce((count, range) => count + range.endUid - range.startUid + 1, 0);
+      // One bounded FETCH per range, avoiding a source round-trip per email.
+      const sourceLimit = Math.min(1024 * 1024, Math.floor(16 * 1024 * 1024 / plannedCount));
+      const fetchQuery = needsFullDetail
+        ? { ...FETCH_INDEX_QUERY, source: { start: 0, maxLength: sourceLimit } }
+        : FETCH_INDEX_QUERY;
       for (const range of ranges) {
-        for await (const message of client.fetch(`${range.startUid}:${range.endUid}`, FETCH_INDEX_QUERY, { uid: true })) {
-          emails.push(this.toSummary(folder, message));
+        for await (const message of client.fetch(`${range.startUid}:${range.endUid}`, fetchQuery, { uid: true })) {
+          const summary = this.toSummary(folder, message);
+          const enriched = message.source
+            ? this.enrichSummaryFromParsed(summary, await this.parseSource(message.source), input.includeAttachmentText)
+            : summary;
+          emails.push(enriched);
+          this.messageCache.set(enriched.id, enriched);
+          this.capMessageCache();
         }
-      }
-      let remainingSourceBytes = 16 * 1024 * 1024;
-      for (let i = 0; i < emails.length; i++) {
-        let summary = emails[i];
-        if (needsFullDetail && remainingSourceBytes > 0) {
-          const maxLength = Math.min(1024 * 1024, Math.floor(remainingSourceBytes / (emails.length - i)));
-          const detail = await client.fetchOne(String(summary.uid), { uid: true, source: { start: 0, maxLength } }, { uid: true });
-          if (detail && detail.source) {
-            remainingSourceBytes -= detail.source.length;
-            summary = this.enrichSummaryFromParsed(summary, await this.parseSource(detail.source), input.includeAttachmentText);
-            emails[i] = summary;
-          }
-        }
-        this.messageCache.set(summary.id, summary);
-        this.capMessageCache();
       }
       const highestUid = plan.checkpointHighestUid ?? plan.endUid;
       return {

--- a/src/services/snooze-service.ts
+++ b/src/services/snooze-service.ts
@@ -3,6 +3,8 @@ import { copyFileSync } from "node:fs";
 import { mkdir, readFile, readdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { ProtonMailConfig, SnoozeRecord } from "../types/index.js";
+import { createOperationClaim, isAbandonedClaim } from "../utils/operation-claim.js";
+import { ensureEmailActionAllowed } from "../utils/runtime-policy.js";
 import { withFileLock } from "../utils/file-lock.js";
 import { parseEmailId } from "../utils/helpers.js";
 import { logger, type Logger } from "../utils/logger.js";
@@ -53,15 +55,7 @@ export class SnoozeService {
   start(): void {
     if (this.started) return;
     this.started = true;
-    // A record stuck in "waking" means the previous process died between
-    // claiming it and recording the outcome — mirrors
-    // DeliveryQueueService.recoverInterruptedSends(). Unlike a queued send,
-    // retrying a move is safe (worst case: "not found" if it already moved),
-    // so this reverts to "pending" for a normal retry on the next
-    // checkDue() pass, rather than a terminal "failed".
-    // Fire-and-forget, but guarded: an unhandled rejection here (e.g. a
-    // file-lock acquisition timeout) would otherwise propagate to index.ts's
-    // global handler and take down the whole server over one bad tick.
+    // Recover abandoned owners before the catch-up pass; live owners keep their claims.
     void this.recoverInterruptedWakes()
       .then(() => this.checkDue())
       .catch((error) => this.log.error("Startup recovery/checkDue failed", "SnoozeService", error));
@@ -90,6 +84,7 @@ export class SnoozeService {
   }
 
   async snooze(emailId: string, wakeAt: string): Promise<SnoozeRecord> {
+    ensureEmailActionAllowed(this.config.runtime, "archive");
     const { folder: originalFolder } = parseEmailId(emailId);
     await this.ensureSnoozeFolder();
     const moved = await this.imapService.moveEmail(emailId, SNOOZE_FOLDER);
@@ -113,21 +108,11 @@ export class SnoozeService {
     return record;
   }
 
-  // Wakes a snooze immediately (used by both cancel and the timer). Moves the
-  // email back to its original folder and marks the record accordingly.
-  //
-  // Two-phase, mirroring DeliveryQueueService.checkDue()'s claim pattern:
-  // claim under a brief lock (flip pending -> waking, so a second wake()
-  // racing the same id — e.g. the 15s timer firing while a manual cancel is
-  // in flight — sees "waking" and backs off instead of double-moving), do
-  // the real network IMAP move OUTSIDE any lock, then re-lock briefly to
-  // record the outcome. Doing the move *inside* the lock held the new
-  // cross-process file lock (file-lock.ts) for a real network round trip —
-  // long enough, under real degraded network conditions, to exceed its
-  // stale-lock timeout and have the lock stolen mid-move by another
-  // process, silently reintroducing the exact lost-update race that lock
-  // exists to prevent.
+  // Claim under the file lock, move outside it, then finalize only if the
+  // same claim still owns the record. Competing cancels return its live status.
   private async wake(id: string, status: "woken" | "canceled"): Promise<SnoozeRecord> {
+    ensureEmailActionAllowed(this.config.runtime, "archive");
+    const claim = createOperationClaim();
     const claimed = await this.withLock(async () => {
       const store = await this.loadUnlocked();
       const record = store.items[id];
@@ -138,11 +123,13 @@ export class SnoozeService {
         return record;
       }
       record.status = "waking";
+      record.claim = claim;
+      delete record.pausedReason;
       await this.save(store);
       return record;
     });
 
-    if (claimed.status !== "waking") {
+    if (claimed.status !== "waking" || claimed.claim?.token !== claim.token) {
       // Already resolved by another wake() call, or nothing to do.
       return claimed;
     }
@@ -160,15 +147,17 @@ export class SnoozeService {
         `Timed out after ${SNOOZE_WAKE_TIMEOUT_MS}ms waking snooze ${id}`,
       );
     } catch (error) {
-      // Revert the claim so checkDue()'s existing failure-counting catch
-      // handler (which only updates a record still "pending") still finds
-      // it there, and the item gets retried on the next checkDue() pass
-      // instead of getting stuck in "waking" forever.
+      // Retry definite failures; a timeout has an unknown move outcome.
       await this.withLock(async () => {
         const store = await this.loadUnlocked();
         const record = store.items[id];
-        if (record && record.status === "waking") {
-          record.status = "pending";
+        if (record && record.status === "waking" && record.claim?.token === claim.token) {
+          const message = error instanceof Error ? error.message : String(error);
+          record.status = message.startsWith("Timed out after") ? "failed" : "pending";
+          if (record.status === "failed") {
+            record.failureReason = `${message} — move outcome is unknown. Check both folders before retrying manually.`;
+          }
+          delete record.claim;
           await this.save(store);
         }
       });
@@ -181,19 +170,16 @@ export class SnoozeService {
       if (!record) {
         throw new Error(`Snoozed email not found for id ${id}`);
       }
-      // Re-check the status fresh under this lock, mirroring
-      // DeliveryQueueService.checkDue()'s finalize (only writes if the
-      // record is still "sending"): a concurrent process's
-      // recoverInterruptedWakes() may have already reverted this record to
-      // "pending" (e.g. this process died between the claim above and here),
-      // and a second wake() could already be in flight for it. Skip the
-      // write rather than clobbering whatever that other path recorded.
-      if (record.status !== "waking") {
+      // Only the owner of this particular claim may finalize it.
+      if (record.status !== "waking" || record.claim?.token !== claim.token) {
         this.log.warn("Skipped duplicate snooze finalize — record no longer \"waking\"", "SnoozeService", { id, status: record.status });
         return record;
       }
       record.currentEmailId = moved.targetEmailId ?? record.currentEmailId;
       record.status = status;
+      delete record.claim;
+      delete record.failureReason;
+      record.failureCount = 0;
       record.wokenAt = new Date().toISOString();
       await this.save(store);
       return record;
@@ -219,6 +205,24 @@ export class SnoozeService {
   }
 
   async checkDue(): Promise<{ woken: number; failed: number }> {
+    await this.recoverInterruptedWakes();
+    try {
+      ensureEmailActionAllowed(this.config.runtime, "archive");
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      await this.withLock(async () => {
+        const store = await this.loadUnlocked();
+        let changed = false;
+        for (const record of Object.values(store.items)) {
+          if (record.status === "pending" && record.pausedReason !== reason) {
+            record.pausedReason = reason;
+            changed = true;
+          }
+        }
+        if (changed) await this.save(store);
+      });
+      return { woken: 0, failed: 0 };
+    }
     const now = Date.now();
     const due = (await this.list()).filter(
       (item) => item.status === "pending" && new Date(item.wakeAt).getTime() <= now,
@@ -228,8 +232,8 @@ export class SnoozeService {
     let failed = 0;
     for (const item of due) {
       try {
-        await this.wake(item.id, "woken");
-        woken += 1;
+        const result = await this.wake(item.id, "woken");
+        if (result.status === "woken") woken += 1;
       } catch (error) {
         this.log.warn("Snooze wake failed", "SnoozeService", { id: item.id, error });
         await this.withLock(async () => {
@@ -287,8 +291,10 @@ export class SnoozeService {
       const store = await this.loadUnlocked();
       let changed = false;
       for (const record of Object.values(store.items)) {
-        if (record.status !== "waking") continue;
-        record.status = "pending";
+        if (record.status !== "waking" || !isAbandonedClaim(record.claim)) continue;
+        record.status = "failed";
+        delete record.claim;
+        record.failureReason = "Interrupted while waking — move outcome is unknown. Check the original and snooze folders before moving the email manually.";
         changed = true;
       }
       if (changed) await this.save(store);
@@ -371,8 +377,7 @@ export class SnoozeService {
     }
   }
 
-  // ponytail: same cross-process race as DeliveryQueueService.save — see that
-  // comment for why it's left unlocked and the real upgrade path (SQLite).
+  // Called while holding the cross-process file lock. Rename is atomic.
   private async save(store: SnoozeFile): Promise<void> {
     await mkdir(dirname(this.storePath), { recursive: true, mode: 0o700 });
     const tempPath = `${this.storePath}.tmp`;

--- a/src/services/template-service.ts
+++ b/src/services/template-service.ts
@@ -176,8 +176,7 @@ export class TemplateService {
     }
   }
 
-  // ponytail: same cross-process race as DeliveryQueueService.save — see that
-  // comment for why it's left unlocked and the real upgrade path (SQLite).
+  // Called while holding the cross-process file lock. Rename is atomic.
   private async save(store: TemplateFile): Promise<void> {
     await mkdir(dirname(this.storePath), { recursive: true, mode: 0o700 });
     const tempPath = `${this.storePath}.tmp`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,7 +36,14 @@ export interface EmailAttachmentInput {
 // two writes that set and clear it.
 export type SnoozeStatus = "pending" | "waking" | "woken" | "canceled" | "failed";
 
+export interface OperationClaim {
+  pid: number;
+  token: string;
+}
+
 export interface SnoozeRecord {
+  claim?: OperationClaim;
+  pausedReason?: string;
   id: string;
   createdAt: string;
   wakeAt: string;
@@ -65,12 +72,12 @@ export interface EmailTemplateRecord {
 export type DeliveryQueueKind = "undo_send" | "scheduled_send";
 // "sending" is a short-lived claim state: set under the lock right before the
 // SMTP call so cancel() and overlapping checkDue() passes can never act on an
-// item that's already in flight. A "sending" record found at startup means
-// the previous process died mid-send; it is never auto-resent (outcome
-// unknown) — see DeliveryQueueService.recoverInterruptedSends.
+// item that's already in flight. Only a dead owner is recovered; uncertain
+// SMTP outcomes are never auto-resent.
 export type DeliveryQueueStatus = "pending" | "sending" | "sent" | "canceled" | "failed";
 
 export interface DeliveryQueueRecord {
+  claim?: OperationClaim;
   id: string;
   kind: DeliveryQueueKind;
   createdAt: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -433,10 +433,8 @@ export interface MailboxSyncCheckpoint {
   rangeEndUid?: number;
   // Disjoint ranges reconciled in this snapshot (new mail plus history).
   scannedRanges?: Array<{ startUid: number; endUid: number }>;
-  // Lowest UID reached so far by repeated full:true backfill calls on this
-  // folder. Persisted so each subsequent full sync continues one window
-  // further back in history instead of re-fetching the same newest window
-  // forever.
+  // Historical scan cursor. Full cycles walk down to UID 1, then restart
+  // at the processed high-water mark to reconcile older messages again.
   backfilledToUid?: number;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -424,6 +424,8 @@ export interface MailboxSyncCheckpoint {
   // call, so it must never treat UIDs outside its own window as expunged).
   rangeStartUid?: number;
   rangeEndUid?: number;
+  // Disjoint ranges reconciled in this snapshot (new mail plus history).
+  scannedRanges?: Array<{ startUid: number; endUid: number }>;
   // Lowest UID reached so far by repeated full:true backfill calls on this
   // folder. Persisted so each subsequent full sync continues one window
   // further back in history instead of re-fetching the same newest window

--- a/src/utils/file-lock.ts
+++ b/src/utils/file-lock.ts
@@ -35,7 +35,8 @@ function lockPathFor(storePath: string): string {
 // could — so this never touches the other process, it only inspects the
 // error: ESRCH means no such process (dead), EPERM means it exists but we
 // lack permission to signal it (still alive), anything else is inconclusive.
-function isProcessAlive(pid: number): boolean | undefined {
+export function isProcessAlive(pid: number): boolean | undefined {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
   try {
     process.kill(pid, 0);
     return true;

--- a/src/utils/operation-claim.ts
+++ b/src/utils/operation-claim.ts
@@ -1,0 +1,13 @@
+import { randomUUID } from "node:crypto";
+import type { OperationClaim } from "../types/index.js";
+import { isProcessAlive } from "./file-lock.js";
+
+export function createOperationClaim(): OperationClaim {
+  return { pid: process.pid, token: randomUUID() };
+}
+
+// Never recover a live or uninspectable owner. Legacy claims have no owner;
+// their outcome must be reported as unknown rather than retried automatically.
+export function isAbandonedClaim(claim?: OperationClaim): boolean {
+  return !claim || isProcessAlive(claim.pid) === false;
+}

--- a/src/utils/runtime-policy.ts
+++ b/src/utils/runtime-policy.ts
@@ -1,5 +1,5 @@
 import type { EmailAction, ProtonRuntimeConfig } from "../types/index.js";
-import { isSelfAddress } from "./helpers.js";
+import { isSelfAddress, normalizeBoolean } from "./helpers.js";
 
 export function sanitizeRuntimeConfig(runtime: ProtonRuntimeConfig): Record<string, unknown> {
   return {
@@ -109,4 +109,54 @@ export function ensureDestructiveConfirmed(
   throw new Error(
     `Confirmation required: ${description}\n\nThis action is irreversible. Call this tool again with confirmed: true after asking the user to confirm.`,
   );
+}
+
+// All alternate tool routes pass through this boundary before doing any I/O.
+// Individual handlers may impose additional restrictions (send, remote drafts).
+const TOOL_ACTIONS: Partial<Record<string, EmailAction>> = {
+  move_email: "move", bulk_move: "move", move_thread: "move",
+  archive_email: "archive", trash_email: "trash", restore_email: "restore",
+  snooze_email: "archive", cancel_snooze: "archive",
+  delete_email: "delete", empty_folder: "delete",
+  delete_folder: "delete", delete_label: "delete",
+};
+
+export function ensureToolActionAllowed(
+  runtime: ProtonRuntimeConfig,
+  tool: string,
+  args: Record<string, unknown>,
+): void {
+  const actions = new Set<EmailAction>();
+  const fixed = TOOL_ACTIONS[tool];
+  if (fixed) actions.add(fixed);
+  if (tool === "batch_email_action" || tool === "apply_thread_action") {
+    const action = String(args.action) as EmailAction;
+    if (!["mark_read", "mark_unread", "star", "unstar", "archive", "trash", "restore", "move", "delete"].includes(action)) {
+      throw new Error("Unsupported email action.");
+    }
+    actions.add(action);
+  }
+  if (tool === "bulk_delete" || tool === "delete_thread") {
+    actions.add(normalizeBoolean(args.permanent, false) ? "delete" : "trash");
+  }
+  if (tool === "mark_email_read") actions.add(!normalizeBoolean(args.isRead, true) ? "mark_unread" : "mark_read");
+  if (tool === "star_email") actions.add(!normalizeBoolean(args.isStarred, true) ? "unstar" : "star");
+  if (["update_message_flags", "bulk_update_flags", "flag_thread", "import_email"].includes(tool)) {
+    ensureMailboxWriteAllowed(runtime);
+    const mapping: Record<string, [EmailAction, EmailAction]> = {
+      "\\seen": ["mark_read", "mark_unread"],
+      "\\flagged": ["star", "unstar"],
+      "\\deleted": ["delete", "restore"],
+    };
+    for (const [key, removing] of [[tool === "import_email" ? "flags" : "flagsToAdd", false], ["flagsToRemove", true]] as const) {
+      for (const flag of Array.isArray(args[key]) ? args[key] as unknown[] : []) {
+        const pair = mapping[String(flag).toLowerCase()];
+        if (pair) actions.add(pair[removing ? 1 : 0]);
+      }
+    }
+  }
+  for (const action of actions) ensureEmailActionAllowed(runtime, action);
+  if (actions.has("delete") && !normalizeBoolean(args.dryRun, false)) {
+    ensureDestructiveConfirmed(runtime, normalizeBoolean(args.confirmed, false), `Permanently delete via ${tool}`);
+  }
 }

--- a/src/utils/runtime-policy.ts
+++ b/src/utils/runtime-policy.ts
@@ -156,7 +156,8 @@ export function ensureToolActionAllowed(
     }
   }
   for (const action of actions) ensureEmailActionAllowed(runtime, action);
-  if (actions.has("delete") && !normalizeBoolean(args.dryRun, false)) {
+  const supportsDryRun = ["batch_email_action", "apply_thread_action", "bulk_delete", "delete_thread", "bulk_update_flags", "flag_thread"].includes(tool);
+  if (actions.has("delete") && !(supportsDryRun && normalizeBoolean(args.dryRun, false))) {
     ensureDestructiveConfirmed(runtime, normalizeBoolean(args.confirmed, false), `Permanently delete via ${tool}`);
   }
 }

--- a/test/index-review-regressions.test.mjs
+++ b/test/index-review-regressions.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LocalIndexService } from '../dist/services/local-index-service.js';
+import { fixture, quietLog } from './support/review-fixtures.mjs';
+const email = { id:'INBOX::1',folder:'INBOX',uid:1,seq:1,subject:'Ordinary',from:[],to:[],cc:[],bcc:[],replyTo:[],isRead:false,isStarred:false,flags:[],hasAttachments:false,attachments:[],labels:[],preview:'uniqueneedle' };
+const snapshot = (emails, extra={}) => ({ syncedAt:new Date().toISOString(),folders:[{path:'INBOX',name:'INBOX',delimiter:'/',flags:[],listed:true,subscribed:true}],folderStats:[{folder:'INBOX',fetched:emails.length,total:1,...extra}],emails });
+test('body-term search survives metadata-only refreshes', async t => {
+ const index = new LocalIndexService(await fixture(t), quietLog);
+ await index.recordSnapshot(snapshot([email]));
+ assert.equal((await index.search({query:'uniqueneedle'})).emails.length,1);
+ await index.recordSnapshot(snapshot([{...email,isRead:true,preview:undefined}], {strategy:'incremental_window'}));
+ const results = await index.search({query:'uniqueneedle'});
+ assert.equal(results.emails.length,1);
+ assert.equal(results.emails[0].isRead,true);
+});
+test('observed empty mailbox removes messages and FTS without affecting other folders', async t => {
+ const index = new LocalIndexService(await fixture(t), quietLog);
+ await index.recordSnapshot(snapshot([email,{...email,id:'Archive::1',folder:'Archive'}]));
+ await index.recordSnapshot(snapshot([], {strategy:'empty',total:0}));
+ assert.equal((await index.getStatus()).storedMessageCount,1);
+ assert.equal((await index.search({query:'uniqueneedle',folder:'INBOX'})).emails.length,0);
+ assert.equal((await index.search({query:'uniqueneedle',folder:'Archive'})).emails.length,1);
+});
+test('incremental snapshots preserve the historical backfill cursor', async t => {
+ const index = new LocalIndexService(await fixture(t), quietLog);
+ await index.recordSnapshot(snapshot([email], {strategy:'full',backfilledToUid:500,uidValidity:'1'}));
+ await index.recordSnapshot(snapshot([email], {strategy:'incremental',uidValidity:'1'}));
+ assert.equal((await index.getSyncCheckpointMap()).INBOX.backfilledToUid,500);
+ await index.recordSnapshot(snapshot([], {strategy:'empty',total:0,uidValidity:'1'}));
+ assert.equal((await index.getSyncCheckpointMap()).INBOX.backfilledToUid,undefined);
+});

--- a/test/simple-imap-sync.test.mjs
+++ b/test/simple-imap-sync.test.mjs
@@ -159,7 +159,7 @@ test("planFolderSync full:true continues backfilling older than the last window 
   assert.equal(plan.backfilledToUid, 44750);
 });
 
-test("planFolderSync full:true reports no more work once backfilled to UID 1", () => {
+test("planFolderSync full:true cycles history again after reaching UID 1", () => {
   const plan = planFolderSync({
     folder: "Archive",
     exists: 22871,
@@ -175,9 +175,9 @@ test("planFolderSync full:true reports no more work once backfilled to UID 1", (
   });
 
   assert.equal(plan.strategy, "full");
-  assert.equal(plan.changed, false);
-  assert.equal(plan.startUid, undefined);
-  assert.equal(plan.backfilledToUid, 1);
+  assert.equal(plan.changed, true);
+  assert.equal(plan.startUid, 45250);
+  assert.equal(plan.backfilledToUid, 45250);
 });
 
 test("planFolderSync full:true restarts backfill from the newest window when uidValidity changed", () => {

--- a/test/snooze.test.mjs
+++ b/test/snooze.test.mjs
@@ -19,7 +19,7 @@ function createConfig(dataDir) {
       readOnly: false,
       allowSend: true,
       allowRemoteDraftSync: true,
-      allowedActions: [],
+      allowedActions: ["archive"],
       startupSync: false,
       autoSyncFolder: "INBOX",
       autoSyncFull: false,

--- a/test/support/claim-owner.mjs
+++ b/test/support/claim-owner.mjs
@@ -1,0 +1,15 @@
+import { DeliveryQueueService } from '../../dist/services/delivery-queue-service.js';
+import { SnoozeService } from '../../dist/services/snooze-service.js';
+import { quietLog, deferred } from './review-fixtures.mjs';
+const gate=deferred();
+process.on('message', async message => {
+ if(message.type==='finish') { gate.resolve(); return; }
+ if(message.type!=='start')return;
+ const {config,kind}=message;
+ const perform=async()=>{process.send({type:'entered'});await gate.promise;return {messageId:'sent-id',targetEmailId:'INBOX::99'};};
+ const service=kind==='send'
+  ? new DeliveryQueueService(config,{sendEmail:perform},quietLog)
+  : new SnoozeService(config,{moveEmail:perform,withTimeout:p=>p},quietLog);
+ try { await service.checkDue();process.send({type:'done'}); }
+ catch(error){process.send({type:'error',message:error.message});}
+});

--- a/test/support/review-fixtures.mjs
+++ b/test/support/review-fixtures.mjs
@@ -1,0 +1,19 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+export const quietLog = { warn() {}, error() {}, info() {}, debug() {} };
+export async function fixture(t, runtime = {}) {
+  const dataDir = await mkdtemp(join(tmpdir(), 'proton-regression-'));
+  t.after(() => rm(dataDir, { recursive: true, force: true }));
+  return {
+    dataDir, smtp: { username: 'owner@example.com' }, imap: { username: 'owner@example.com' },
+    autoSync: false, cacheEnabled: true, syncInterval: 5,
+    runtime: { readOnly: false, allowSend: true, allowedActions: ['mark_read','mark_unread','star','unstar','move','archive','trash','restore','delete'],
+      confirmDestructive: false, restrictOutboundToSelf: false, opDelayMs: 0, ...runtime },
+  };
+}
+export function deferred() {
+  let resolve;
+  const promise = new Promise(r => { resolve = r; });
+  return { promise, resolve };
+}

--- a/test/sync-review-regressions.test.mjs
+++ b/test/sync-review-regressions.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SimpleIMAPService, planFolderSync } from '../dist/services/simple-imap-service.js';
+import { LocalIndexService } from '../dist/services/local-index-service.js';
+import { fixture, quietLog } from './support/review-fixtures.mjs';
+const plan = (checkpoint, extra={}) => planFolderSync({folder:'INBOX',exists:100000,uidNext:100001,uidValidity:'1',limit:50,full:false,checkpoint,...extra});
+
+test('large incremental backlogs progress in bounded batches, including limit one', () => {
+ for (const limit of [1,50,500]) {
+  let high=1000;
+  while(high<1200) {
+   const batch=plan({highestUid:high,uidValidity:'1'}, {uidNext:1201,limit});
+   assert.ok(batch.endUid-batch.startUid+1<=limit);
+   assert.ok(batch.startUid<=high+1, 'must not skip UIDs');
+   assert.ok(batch.checkpointHighestUid>high, 'must make forward progress');
+   high=batch.checkpointHighestUid;
+  }
+  assert.equal(high,1200);
+ }
+});
+test('full sync refreshes new mail during and after backfill within the total budget', () => {
+ for(const floor of [500,1]) {
+  const p=plan({highestUid:1000,backfilledToUid:floor,uidValidity:'1'},{full:true,uidNext:1002});
+  const ranges=[p,...(p.refreshRange?[p.refreshRange]:[])];
+  assert.ok(ranges.some(r=>r.startUid<=1001 && r.endUid>=1001));
+  assert.ok(ranges.reduce((n,r)=>n+r.endUid-r.startUid+1,0)<=50);
+  assert.equal(p.checkpointHighestUid,1001);
+ }
+});
+
+test('full cycles update old flags and expunges and discover new mail after completed backfill', async t => {
+ const config=await fixture(t);
+ const imap=new SimpleIMAPService(config,quietLog);
+ const index=new LocalIndexService(config,quietLog);
+ const folder={path:'INBOX',name:'INBOX',delimiter:'/',flags:[],listed:true,subscribed:true};
+ const live=new Map(Array.from({length:6},(_,i)=>[i+1,{uid:i+1,seq:i+1,envelope:{subject:'message '+(i+1)},flags:new Set(),size:40}]));
+ const client={mailbox:{uidNext:7,uidValidity:1n,exists:6},async *fetch(range){const [lo,hi]=range.split(':').map(Number);for(const [uid,msg] of live)if(uid>=lo&&uid<=hi)yield msg;},async fetchOne(uid){return {uid:Number(uid),source:Buffer.from('Subject: message\r\n\r\nuniqueneedle')};}};
+ imap.withMailbox=async(_folder,_readOnly,fn)=>fn(client);
+ async function cycle() {
+  const batch=await imap.collectFolderForIndex('INBOX',{full:true,limit:3,includeAttachmentText:true,checkpoint:(await index.getSyncCheckpointMap()).INBOX,syncedAt:new Date().toISOString()});
+  assert.ok(batch.emails.length<=3);
+  await index.recordSnapshot({folders:[folder],emails:batch.emails,folderStats:[batch.checkpoint],syncedAt:new Date().toISOString()});
+ }
+ await cycle();await cycle();
+ assert.equal((await index.getStatus()).storedMessageCount,6);
+ live.delete(1);live.get(2).flags.add('\\Seen');live.set(7,{uid:7,seq:6,envelope:{subject:'new mail'},flags:new Set(),size:40});client.mailbox.uidNext=8;
+ for(let i=0;i<4;i++)await cycle();
+ const results=(await index.search({limit:100})).emails;
+ assert.ok(results.some(e=>e.uid===7));
+ assert.ok(!results.some(e=>e.uid===1));
+ assert.equal(results.find(e=>e.uid===2).isRead,true);
+ assert.equal((await index.search({query:'uniqueneedle'})).emails.length,6);
+});
+
+test('source indexing is bounded per message and per folder', async t => {
+ const imap=new SimpleIMAPService(await fixture(t),quietLog);
+ let requested=0;
+ const client={mailbox:{uidNext:51,uidValidity:1n,exists:50},async *fetch(){for(let uid=1;uid<=50;uid++)yield {uid,seq:uid,envelope:{subject:'large'},size:100*1024*1024};},async fetchOne(uid,query){assert.ok(query.source.maxLength<=1024*1024);requested+=query.source.maxLength;return {uid:Number(uid),source:Buffer.alloc(query.source.maxLength,32)};}};
+ imap.withMailbox=async(_folder,_readOnly,fn)=>fn(client);
+ const result=await imap.collectFolderForIndex('INBOX',{full:false,limit:50,includeAttachmentText:false,syncedAt:new Date().toISOString()});
+ assert.equal(result.emails.length,50);
+ assert.ok(requested<=16*1024*1024);
+ assert.equal(result.checkpoint.highestUid,50);
+});

--- a/test/sync-review-regressions.test.mjs
+++ b/test/sync-review-regressions.test.mjs
@@ -34,7 +34,7 @@ test('full cycles update old flags and expunges and discover new mail after comp
  const index=new LocalIndexService(config,quietLog);
  const folder={path:'INBOX',name:'INBOX',delimiter:'/',flags:[],listed:true,subscribed:true};
  const live=new Map(Array.from({length:6},(_,i)=>[i+1,{uid:i+1,seq:i+1,envelope:{subject:'message '+(i+1)},flags:new Set(),size:40}]));
- const client={mailbox:{uidNext:7,uidValidity:1n,exists:6},async *fetch(range){const [lo,hi]=range.split(':').map(Number);for(const [uid,msg] of live)if(uid>=lo&&uid<=hi)yield msg;},async fetchOne(uid){return {uid:Number(uid),source:Buffer.from('Subject: message\r\n\r\nuniqueneedle')};}};
+ const client={mailbox:{uidNext:7,uidValidity:1n,exists:6},async *fetch(range,query){const [lo,hi]=range.split(':').map(Number);for(const [uid,msg] of live)if(uid>=lo&&uid<=hi)yield {...msg,...(query.source?{source:Buffer.from("Subject: message\r\n\r\nuniqueneedle")}: {})};},async fetchOne(uid){return {uid:Number(uid),source:Buffer.from('Subject: message\r\n\r\nuniqueneedle')};}};
  imap.withMailbox=async(_folder,_readOnly,fn)=>fn(client);
  async function cycle() {
   const batch=await imap.collectFolderForIndex('INBOX',{full:true,limit:3,includeAttachmentText:true,checkpoint:(await index.getSyncCheckpointMap()).INBOX,syncedAt:new Date().toISOString()});
@@ -55,7 +55,13 @@ test('full cycles update old flags and expunges and discover new mail after comp
 test('source indexing is bounded per message and per folder', async t => {
  const imap=new SimpleIMAPService(await fixture(t),quietLog);
  let requested=0;
- const client={mailbox:{uidNext:51,uidValidity:1n,exists:50},async *fetch(){for(let uid=1;uid<=50;uid++)yield {uid,seq:uid,envelope:{subject:'large'},size:100*1024*1024};},async fetchOne(uid,query){assert.ok(query.source.maxLength<=1024*1024);requested+=query.source.maxLength;return {uid:Number(uid),source:Buffer.alloc(query.source.maxLength,32)};}};
+ const client={mailbox:{uidNext:51,uidValidity:1n,exists:50},async *fetch(_range,query){
+  assert.ok(query.source.maxLength<=1024*1024);
+  for(let uid=1;uid<=50;uid++) {
+   requested+=query.source.maxLength;
+   yield {uid,seq:uid,envelope:{subject:'large'},size:100*1024*1024,source:Buffer.alloc(query.source.maxLength,32)};
+  }
+ }};
  imap.withMailbox=async(_folder,_readOnly,fn)=>fn(client);
  const result=await imap.collectFolderForIndex('INBOX',{full:false,limit:50,includeAttachmentText:false,syncedAt:new Date().toISOString()});
  assert.equal(result.emails.length,50);

--- a/test/sync-review-regressions.test.mjs
+++ b/test/sync-review-regressions.test.mjs
@@ -75,3 +75,13 @@ test('full sync discovers the first message after an empty-mailbox checkpoint', 
  assert.equal(p.endUid,1);
  assert.equal(p.checkpointHighestUid,1);
 });
+
+test('partial source indexing preserves authoritative attachment metadata', async t => {
+ const imap=new SimpleIMAPService(await fixture(t),quietLog);
+ const attachments=[{id:'1',filename:'large.bin',size:5000000,contentType:'application/octet-stream'}];
+ imap.toSummary=()=>({id:'INBOX::1',uid:1,folder:'INBOX',attachments,hasAttachments:true});
+ const source=Buffer.from('Content-Type: application/octet-stream\r\nContent-Disposition: attachment; filename="large.bin"\r\n\r\npartial');
+ imap.withMailbox=async(_folder,_readOnly,fn)=>fn({mailbox:{uidNext:2,uidValidity:1n,exists:1},async *fetch(){yield {uid:1,size:5000200,source};}});
+ const result=await imap.collectFolderForIndex('INBOX',{full:false,limit:1,includeAttachmentText:false,syncedAt:new Date().toISOString()});
+ assert.deepEqual(result.emails[0].attachments,attachments);
+});

--- a/test/sync-review-regressions.test.mjs
+++ b/test/sync-review-regressions.test.mjs
@@ -62,3 +62,10 @@ test('source indexing is bounded per message and per folder', async t => {
  assert.ok(requested<=16*1024*1024);
  assert.equal(result.checkpoint.highestUid,50);
 });
+
+test('full sync discovers the first message after an empty-mailbox checkpoint', () => {
+ const p=plan({highestUid:0,uidValidity:'1',total:0},{full:true,exists:1,uidNext:2});
+ assert.equal(p.startUid,1);
+ assert.equal(p.endUid,1);
+ assert.equal(p.checkpointHighestUid,1);
+});

--- a/test/tool-policy.test.mjs
+++ b/test/tool-policy.test.mjs
@@ -47,3 +47,12 @@ test('alternate tools cannot bypass the action allowlist', async t => {
   ]) await assert.rejects(handler({ method: 'tools/call', params: { name, arguments: args } }, {}), /disabled/);
   assert.doesNotThrow(() => ensureToolActionAllowed(config.runtime, 'update_message_flags', { flagsToAdd: ['\\Seen'] }));
 });
+
+test('unsupported dryRun cannot bypass confirmation on flag updates or imports', async t => {
+ const app=createServer(await fixture(t,{confirmDestructive:true}));
+ const handler=app.server._requestHandlers.get('tools/call');
+ for(const [name,args] of [
+  ['update_message_flags',{emailId:'INBOX::1',flagsToAdd:['\\Deleted'],dryRun:true}],
+  ['import_email',{flags:['\\Deleted'],dryRun:true}],
+ ]) await assert.rejects(handler({method:'tools/call',params:{name,arguments:args}},{}),/Confirmation required/);
+});

--- a/test/tool-policy.test.mjs
+++ b/test/tool-policy.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from '../dist/index.js';
+import { fixture } from './support/review-fixtures.mjs';
+import { ensureToolActionAllowed } from '../dist/utils/runtime-policy.js';
+
+const deletionRoutes = [
+  ['delete_email', { emailId: 'INBOX::1' }],
+  ['batch_email_action', { emailIds: ['INBOX::1'], action: 'delete' }],
+  ['apply_thread_action', { threadId: 'thread', action: 'delete' }],
+  ['bulk_delete', { emailIds: ['INBOX::1'], permanent: true }],
+  ['delete_thread', { messageId: 'message', permanent: true }],
+  ['update_message_flags', { emailId: 'INBOX::1', flagsToAdd: ['\\Deleted'] }],
+];
+for (const [name, args] of deletionRoutes) {
+  test(`${name} rejects unconfirmed deletion before any mailbox/index access`, async t => {
+    const app = createServer(await fixture(t, { confirmDestructive: true }));
+    let calls = 0;
+    for (const key of ['deleteEmail', 'bulkDelete', 'deleteThread', 'updateMessageFlags', 'collectEmailsForIndex']) app.imapService[key] = async () => { calls++; };
+    app.localIndexService.getThreadById = async () => { calls++; };
+    const handler = app.server._requestHandlers.get('tools/call');
+    await assert.rejects(handler({ method: 'tools/call', params: { name, arguments: args } }, {}), /Confirmation required/);
+    assert.equal(calls, 0);
+  });
+}
+test('confirmed batch deletion executes and dry run does not require confirmation', async t => {
+  const config = await fixture(t, { confirmDestructive: true });
+  const app = createServer(config);
+  let calls = 0;
+  app.imapService.deleteEmail = async () => { calls++; return { deleted: true }; };
+  const handler = app.server._requestHandlers.get('tools/call');
+  await handler({ method: 'tools/call', params: { name: 'batch_email_action', arguments: { emailIds: ['INBOX::1'], action: 'delete', confirmed: true } } }, {});
+  assert.equal(calls, 1);
+  assert.doesNotThrow(() => ensureToolActionAllowed(config.runtime, 'batch_email_action', { action: 'delete', dryRun: true }));
+});
+test('alternate tools cannot bypass the action allowlist', async t => {
+  const config = await fixture(t, { allowedActions: ['mark_read'] });
+  const app = createServer(config);
+  const handler = app.server._requestHandlers.get('tools/call');
+  for (const [name, args] of [
+    ['move_email', { emailId: 'INBOX::1', targetFolder: 'Trash' }],
+    ['bulk_move', {}], ['move_thread', {}], ['bulk_delete', { permanent: false }],
+    ['bulk_delete', { permanent: 'true' }], ['delete_email', { confirmed: true }],
+    ['update_message_flags', { flagsToAdd: ['\\Flagged'] }],
+    ['bulk_update_flags', { flagsToRemove: ['\\Seen'] }],
+    ['flag_thread', { flagsToAdd: ['\\Deleted'] }],
+  ]) await assert.rejects(handler({ method: 'tools/call', params: { name, arguments: args } }, {}), /disabled/);
+  assert.doesNotThrow(() => ensureToolActionAllowed(config.runtime, 'update_message_flags', { flagsToAdd: ['\\Seen'] }));
+});

--- a/test/worker-review-regressions.test.mjs
+++ b/test/worker-review-regressions.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { once } from 'node:events';
+import { DeliveryQueueService } from '../dist/services/delivery-queue-service.js';
+import { SnoozeService } from '../dist/services/snooze-service.js';
+import { fixture, quietLog, deferred } from './support/review-fixtures.mjs';
+const past=new Date(0).toISOString();
+const payload={to:['owner@example.com'],subject:'test',body:'test'};
+
+for(const kind of ['send','snooze'])for(const killOwner of [false,true]) {
+ test(`${kind}: recovery ${killOwner?'handles a dead owner without retrying':'preserves another process’s live claim'}`, {timeout:10000}, async t => {
+  const config=await fixture(t);
+  let calls=0;
+  const service=kind==='send'?new DeliveryQueueService(config,{sendEmail:async()=>{calls++;}},quietLog):new SnoozeService(config,{createFolder:async()=>{},moveEmail:async()=>{calls++;return {targetEmailId:'Folders/MCP-Snoozed::1'};},withTimeout:p=>p},quietLog);
+  const record=kind==='send'?await service.enqueue(payload,past,'scheduled_send'):await service.snooze('INBOX::1',past);
+  calls=0;
+  const child=fork(new URL('./support/claim-owner.mjs',import.meta.url),[],{silent:true});
+  child.stdout.resume();child.stderr.resume();
+  t.after(async()=>{if(child.exitCode===null&&child.signalCode===null){const exited=once(child,'exit');child.kill();await exited;}});
+  const entered=once(child,'message');child.send({type:'start',config,kind});
+  assert.equal((await entered)[0].type,'entered');
+  if(killOwner){const exited=once(child,'exit');child.kill('SIGKILL');await exited;}
+  await service.checkDue();
+  assert.equal(calls,0);
+  let state=await service.get(record.id);
+  if(killOwner){assert.equal(state.status,'failed');assert.match(state.failureReason,/unknown/);}
+  else {
+   assert.equal(state.status,kind==='send'?'sending':'waking');
+   const done=once(child,'message');child.send({type:'finish'});assert.equal((await done)[0].type,'done');
+   state=await service.get(record.id);assert.equal(state.status,kind==='send'?'sent':'woken');
+  }
+ });
+}
+test('concurrent cancels issue one wake move and distinguish the in-progress result', async t => {
+ const config=await fixture(t), entered=deferred(), finish=deferred();let wakeCalls=0;
+ const imap={createFolder:async()=>{},withTimeout:p=>p,moveEmail:async(_id,to)=>{if(to==='INBOX'){wakeCalls++;entered.resolve();await finish.promise;}return {targetEmailId:to+'::2'};}};
+ const snooze=new SnoozeService(config,imap,quietLog);
+ const record=await snooze.snooze('INBOX::1',past);
+ const first=snooze.cancel(record.id);await entered.promise;
+ const second=await snooze.cancel(record.id);
+ assert.equal(second.status,'waking');assert.equal(wakeCalls,1);
+ finish.resolve();assert.equal((await first).status,'canceled');
+});
+test('read-only and archive-disabled workers pause snoozes without consuming retries', async t => {
+ const config=await fixture(t);let calls=0;
+ const imap={createFolder:async()=>{},withTimeout:p=>p,moveEmail:async()=>{calls++;return {targetEmailId:'INBOX::2'};}};
+ const snooze=new SnoozeService(config,imap,quietLog);const record=await snooze.snooze('INBOX::1',past);calls=0;
+ for(const policy of [{readOnly:true},{readOnly:false,allowedActions:['mark_read']}]){
+  Object.assign(config.runtime,policy);
+  for(let i=0;i<6;i++)assert.deepEqual(await snooze.checkDue(),{woken:0,failed:0});
+  const state=await snooze.get(record.id);
+  assert.equal(state.status,'pending');assert.equal(state.failureCount,undefined);assert.match(state.pausedReason,/disabled/);
+  await assert.rejects(snooze.cancel(record.id),/disabled/);
+ }
+ assert.equal(calls,0);config.runtime.allowedActions=['archive'];
+ assert.deepEqual(await snooze.checkDue(),{woken:1,failed:0});assert.equal(calls,1);
+ assert.equal((await snooze.get(record.id)).pausedReason,undefined);
+});


### PR DESCRIPTION
Closes nine reproduced authorization, indexing, and worker-concurrency defects. An unconfirmed batch delete previously bypassed confirmation; a flags-only sync removed body search results; completed full backfills stopped finding new mail; and another server's startup could mark a live send failed.

Changes:
- Apply shared action/confirmation checks to equivalent single, bulk, thread, generic-flag, and CLI routes; forward CLI confirmation flags and enforce reply/forward recipient restrictions. Reject unsupported dry-run bypasses.
- Preserve FTS body text and reply references during metadata refreshes; clear observed empty mailboxes; reconcile scanned UID ranges without removing unscanned messages.
- Bound incremental batches, preserve historical progress, and share full-sync batches between new mail and cycling historical refreshes. Batch bounded source reads rather than adding a network call per message; preserve authoritative attachment metadata when source is partial.
- Persist operation owner PID/token, leave live workers' claims alone, and report abandoned send/wake outcomes as unknown without automatic retry. Prevent duplicate wake claims and pause policy-blocked snoozes without spending retries.
- Align Node support with CI (20/22/24) and update behavior docs and stale locking comments.

Validation on final commit:
- 204 tests pass on Node 20.20.2, 22.23.2, and 24.20.0, including real child-process concurrency and owner-death regression tests.
- `npm run release:check` passes on each runtime (type check, build, tests, package dry run).
- `npm audit` reports zero known vulnerabilities; `git diff --check` passes.
- No live Proton Bridge account was used; SMTP/IMAP operations were mocked, while SQLite and subprocess coordination were exercised locally.

Behavior notes: indexing source is best effort, capped at 1 MiB per message and 16 MiB per folder per cycle; full reads/exports remain available. Restart older MCP workers when upgrading so every process uses claim ownership. Persistent JSON stores remain compatible; no database migration or release/version bump is included.
